### PR TITLE
BUG: Remove const_cast wherever that was possible

### DIFF
--- a/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
+++ b/Examples/antsDisplacementAndVelocityFieldRegistrationCommandIterationUpdate.h
@@ -102,7 +102,7 @@ public:
 
       typedef itk::GradientDescentOptimizerv4Template<RealType> GradientDescentOptimizerType;
       GradientDescentOptimizerType * optimizer = reinterpret_cast<GradientDescentOptimizerType *>(
-          const_cast<typename TFilter::OptimizerType *>( const_cast<TFilter *>( filter )->GetOptimizer() ) );
+                                                                      const_cast<TFilter *>( filter )->GetModifiableOptimizer() );
 
       // TODO:  This looks very wrong.  There is a const_cast above, and then the change
       //       of the number of iterations here on what should be a const object.

--- a/Examples/antsMotionCorr.cxx
+++ b/Examples/antsMotionCorr.cxx
@@ -120,8 +120,7 @@ public:
                      << std::endl;
 
       typedef itk::ConjugateGradientLineSearchOptimizerv4 GradientDescentOptimizerType;
-      GradientDescentOptimizerType * optimizer = reinterpret_cast<GradientDescentOptimizerType *>(
-          const_cast<typename TFilter::OptimizerType *>( filter->GetOptimizer() ) );
+      GradientDescentOptimizerType * optimizer = reinterpret_cast<GradientDescentOptimizerType *>( filter->GetModifiableOptimizer() );
       optimizer->SetNumberOfIterations( this->m_NumberOfIterations[currentLevel] );
       optimizer->SetMinimumConvergenceValue( 1.e-7 );
       optimizer->SetConvergenceWindowSize( 10 );
@@ -291,8 +290,7 @@ public:
               << std::endl;
 
     typedef itk::ConjugateGradientLineSearchOptimizerv4 OptimizerType;
-    OptimizerType * optimizer = reinterpret_cast<OptimizerType *>(
-        const_cast<typename TFilter::OptimizerType *>( filter->GetOptimizer() ) );
+    OptimizerType * optimizer = reinterpret_cast<OptimizerType *>( filter->GetModifiableOptimizer() );
     optimizer->SetNumberOfIterations( this->m_NumberOfIterations[currentLevel] );
     optimizer->SetMinimumConvergenceValue( 1.e-7 );
     optimizer->SetConvergenceWindowSize( 10 );
@@ -989,7 +987,7 @@ int ants_motion( itk::ants::CommandLineParser *parser )
           std::cerr << "Exception caught: " << e << std::endl;
           return EXIT_FAILURE;
           }
-        compositeTransform->AddTransform( const_cast<AffineTransformType *>( affineRegistration->GetOutput()->Get() ) );
+        compositeTransform->AddTransform( affineRegistration->GetModifiableTransform() );
         // Write out the affine transform
         std::string filename = outputPrefix + std::string("TimeSlice") + ants_moco_to_string<unsigned int>(timedim)
           + std::string( "Affine.txt" );
@@ -1056,7 +1054,7 @@ int ants_motion( itk::ants::CommandLineParser *parser )
           std::cerr << "Exception caught: " << e << std::endl;
           return EXIT_FAILURE;
           }
-        compositeTransform->AddTransform( const_cast<RigidTransformType *>( rigidRegistration->GetOutput()->Get() ) );
+        compositeTransform->AddTransform( rigidRegistration->GetModifiableTransform() );
         // Write out the rigid transform
         std::string filename = outputPrefix + std::string("TimeSlice") + ants_moco_to_string<unsigned int>(timedim)
           + std::string( "Rigid.txt" );
@@ -1102,7 +1100,7 @@ int ants_motion( itk::ants::CommandLineParser *parser )
           DisplacementFieldRegistrationType::New();
 
         typename GaussianDisplacementFieldTransformType::Pointer outputDisplacementFieldTransform =
-          const_cast<GaussianDisplacementFieldTransformType *>( displacementFieldRegistration->GetOutput()->Get() );
+                                                                      displacementFieldRegistration->GetModifiableTransform();
 
         // Create the transform adaptors
 
@@ -1187,7 +1185,7 @@ int ants_motion( itk::ants::CommandLineParser *parser )
           DisplacementFieldRegistrationType::New();
 
         typename DisplacementFieldTransformType::Pointer outputDisplacementFieldTransform =
-          const_cast<DisplacementFieldTransformType *>( displacementFieldRegistration->GetOutput()->Get() );
+                                                                  displacementFieldRegistration->GetModifiableTransform();
 
         // Create the transform adaptors
 

--- a/Examples/antsRegistrationCommandIterationUpdate.h
+++ b/Examples/antsRegistrationCommandIterationUpdate.h
@@ -69,8 +69,7 @@ public:
       m_clock.Start();
 
       typedef itk::GradientDescentOptimizerv4Template<typename TFilter::RealType> GradientDescentOptimizerType;
-      GradientDescentOptimizerType * optimizer = reinterpret_cast<GradientDescentOptimizerType *>(
-          const_cast<typename TFilter::OptimizerType *>( const_cast<TFilter *>( filter )->GetOptimizer() ) );
+      GradientDescentOptimizerType * optimizer = reinterpret_cast<GradientDescentOptimizerType *>( const_cast<TFilter *>( filter )->GetModifiableOptimizer() );
 
       // TODO:  This looks very wrong.  There is a const_cast above, and then the change
       //       of the number of iterations here on what should be a const object.

--- a/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
+++ b/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
@@ -83,11 +83,8 @@ public:
       m_clock.Start();
 
       typedef itk::GradientDescentOptimizerv4<ParametersValueType> GradientDescentOptimizerType;
-      GradientDescentOptimizerType * optimizer = reinterpret_cast<GradientDescentOptimizerType *>(
-          const_cast<typename TOptimizer::OptimizerType *>( const_cast<TOptimizer *>( this->m_Optimizer )->GetOptimizer() ) );
+      GradientDescentOptimizerType * optimizer = reinterpret_cast<GradientDescentOptimizerType *>( this->m_Optimizer->GetModifiableOptimizer() );
 
-      // TODO:  This looks very wrong.  There is a const_cast above, and then the change
-      //       of the number of iterations here on what should be a const object.
       optimizer->SetNumberOfIterations( this->m_NumberOfIterations[currentLevel] );
       }
     else
@@ -209,7 +206,7 @@ public:
                                   MeasureType & metricValue ) const
   {
     // Get the registration metric from the optimizer
-    typename MetricType::ConstPointer inputMetric( dynamic_cast<MetricType const *>( myOptimizer->GetMetric() ) );
+    typename MetricType::Pointer inputMetric( dynamic_cast<MetricType *>( myOptimizer->GetModifiableMetric() ) );
 
     // Define the CC metric type
     // This metric type is used to measure the general similarity metric between the original input fixed and moving
@@ -235,14 +232,12 @@ public:
       {
       typename CompositeTransformType::Pointer myFixedTransform = CompositeTransformType::New();
 
-      // Const_cast just makes it possible to cast the metric's transform to a composite transform, so we can copy each
+      // We cast the metric's transform to a composite transform, so we can copy each
       // of its sub transforms to a new instance.
       // Notice that the metric transform will not be changed inside this fuction.
-      // NOTE:  This will not be needed when ITKv4 is updated to include const versions of all get functions.
-      // TODO: Remove const_cast once ITKv4 is fixed to allow const Get Macro functions.
       typedef typename MetricType::FixedTransformType FixedTransformType;
       typename CompositeTransformType::ConstPointer inputFixedTransform =
-        dynamic_cast<CompositeTransformType *>( const_cast<FixedTransformType *>( inputMetric->GetFixedTransform() ) );
+                                          dynamic_cast<CompositeTransformType *>( inputMetric->GetModifiableFixedTransform() );
       const unsigned int N = inputFixedTransform->GetNumberOfTransforms();
       for( unsigned int i = 0; i < N; i++ )
         {
@@ -275,9 +270,9 @@ public:
     // Same procedure for the moving transform. Moving transform is always a Composite transform.
     typedef typename MetricType::MovingTransformType MovingTransformType;
     typename CompositeTransformType::Pointer movingTransform = CompositeTransformType::New();
-    // TODO: Remove const_cast once ITKv4 is fixed to allow const Get Macro functions.
+
     typename CompositeTransformType::ConstPointer inputMovingTransform =
-      dynamic_cast<CompositeTransformType *>( const_cast<MovingTransformType *>( inputMetric->GetMovingTransform() ) );
+                                                      dynamic_cast<CompositeTransformType *>( inputMetric->GetModifiableMovingTransform() );
     const unsigned int N = inputMovingTransform->GetNumberOfTransforms();
     for( unsigned int i = 0; i < N; i++ )
       {
@@ -305,14 +300,14 @@ public:
   void WriteIntervalVolumes(itk::WeakPointer<OptimizerType> myOptimizer)
   {
     // Get the registration metric from the optimizer
-    typename MetricType::ConstPointer inputMetric( dynamic_cast<MetricType const *>( myOptimizer->GetMetric() ) );
+    typename MetricType::Pointer inputMetric( dynamic_cast<MetricType *>( myOptimizer->GetModifiableMetric() ) );
 
     // First, compute the moving transform
     typedef typename MetricType::MovingTransformType MovingTransformType;
     typename CompositeTransformType::Pointer movingTransform = CompositeTransformType::New();
-    // TODO: Remove const_cast once ITKv4 is fixed to allow const Get Macro functions.
+
     typename CompositeTransformType::ConstPointer inputMovingTransform =
-      dynamic_cast<CompositeTransformType *>( const_cast<MovingTransformType *>( inputMetric->GetMovingTransform() ) );
+                                                        dynamic_cast<CompositeTransformType *>( inputMetric->GetModifiableMovingTransform() );
     const unsigned int N = inputMovingTransform->GetNumberOfTransforms();
     for( unsigned int i = 0; i < N; i++ )
       {

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -1327,13 +1327,11 @@ RegistrationHelper<TComputeType, VImageDimension>
         // which is incorporated into the fixed image header.
         if( this->m_ApplyLinearTransformsToFixedImageHeader && this->m_AllPreviousTransformsAreLinear )
           {
-          this->m_CompositeLinearTransformForFixedImageHeader->AddTransform( const_cast<AffineTransformType *>(
-                                                                               affineRegistration->GetOutput()->Get() ) );
+          this->m_CompositeLinearTransformForFixedImageHeader->AddTransform( affineRegistration->GetModifiableTransform() );
           }
         else
           {
-          this->m_CompositeTransform->AddTransform( const_cast<AffineTransformType *>(
-                                                      affineRegistration->GetOutput()->Get() ) );
+          this->m_CompositeTransform->AddTransform( affineRegistration->GetModifiableTransform() );
           }
         }
         break;
@@ -1402,13 +1400,11 @@ RegistrationHelper<TComputeType, VImageDimension>
         // which is incorporated into the fixed image header.
         if( this->m_ApplyLinearTransformsToFixedImageHeader && this->m_AllPreviousTransformsAreLinear )
           {
-          this->m_CompositeLinearTransformForFixedImageHeader->AddTransform( const_cast<RigidTransformType *>(
-                                                                               rigidRegistration->GetOutput()->Get() ) );
+          this->m_CompositeLinearTransformForFixedImageHeader->AddTransform( rigidRegistration->GetModifiableTransform() );
           }
         else
           {
-          this->m_CompositeTransform->AddTransform( const_cast<RigidTransformType *>( rigidRegistration->GetOutput()->
-                                                                                      Get() ) );
+          this->m_CompositeTransform->AddTransform( rigidRegistration->GetModifiableTransform() );
           }
         }
         break;
@@ -1478,13 +1474,11 @@ RegistrationHelper<TComputeType, VImageDimension>
         // which is incorporated into the fixed image header.
         if( this->m_ApplyLinearTransformsToFixedImageHeader && this->m_AllPreviousTransformsAreLinear )
           {
-          this->m_CompositeLinearTransformForFixedImageHeader->AddTransform( const_cast<CompositeAffineTransformType *>(
-                                                                               affineRegistration->GetOutput()->Get() ) );
+          this->m_CompositeLinearTransformForFixedImageHeader->AddTransform( affineRegistration->GetModifiableTransform() );
           }
         else
           {
-          this->m_CompositeTransform->AddTransform( const_cast<CompositeAffineTransformType *>( affineRegistration->
-                                                                                                GetOutput()->Get() ) );
+          this->m_CompositeTransform->AddTransform( affineRegistration->GetModifiableTransform() );
           }
         }
         break;
@@ -1554,13 +1548,11 @@ RegistrationHelper<TComputeType, VImageDimension>
         // which is incorporated into the fixed image header.
         if( this->m_ApplyLinearTransformsToFixedImageHeader && this->m_AllPreviousTransformsAreLinear )
           {
-          this->m_CompositeLinearTransformForFixedImageHeader->AddTransform( const_cast<SimilarityTransformType *>(
-                                                                               similarityRegistration->GetOutput()->Get() ) );
+          this->m_CompositeLinearTransformForFixedImageHeader->AddTransform( similarityRegistration->GetModifiableTransform() );
           }
         else
           {
-          this->m_CompositeTransform->AddTransform( const_cast<SimilarityTransformType *>( similarityRegistration->
-                                                                                           GetOutput()->Get() ) );
+          this->m_CompositeTransform->AddTransform( similarityRegistration->GetModifiableTransform() );
           }
         }
         break;
@@ -1630,14 +1622,11 @@ RegistrationHelper<TComputeType, VImageDimension>
         // which is incorporated into the fixed image header.
         if( this->m_ApplyLinearTransformsToFixedImageHeader && this->m_AllPreviousTransformsAreLinear )
           {
-          this->m_CompositeLinearTransformForFixedImageHeader->AddTransform( const_cast<TranslationTransformType *>(
-                                                                               translationRegistration->GetOutput()->
-                                                                               Get() ) );
+          this->m_CompositeLinearTransformForFixedImageHeader->AddTransform( translationRegistration->GetModifiableTransform() );
           }
         else
           {
-          this->m_CompositeTransform->AddTransform( const_cast<TranslationTransformType *>( translationRegistration->
-                                                                                            GetOutput()->Get() ) );
+          this->m_CompositeTransform->AddTransform( translationRegistration->GetModifiableTransform() );
           }
         }
         break;
@@ -1672,8 +1661,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           displacementFieldRegistration->SetOptimizerWeights( optimizerWeights );
           }
 
-        typename GaussianDisplacementFieldTransformType::Pointer outputDisplacementFieldTransform =
-          const_cast<GaussianDisplacementFieldTransformType *>( displacementFieldRegistration->GetOutput()->Get() );
+        typename GaussianDisplacementFieldTransformType::Pointer outputDisplacementFieldTransform = displacementFieldRegistration->GetModifiableTransform();
 
         // Create the transform adaptors
 
@@ -1813,8 +1801,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           displacementFieldRegistration->SetOptimizerWeights( optimizerWeights );
           }
 
-        typename BSplineDisplacementFieldTransformType::Pointer outputDisplacementFieldTransform =
-          const_cast<BSplineDisplacementFieldTransformType *>( displacementFieldRegistration->GetOutput()->Get() );
+        typename BSplineDisplacementFieldTransformType::Pointer outputDisplacementFieldTransform = displacementFieldRegistration->GetModifiableTransform();
         outputDisplacementFieldTransform->SetDisplacementField( displacementField );
 
         // Create the transform adaptors
@@ -1965,8 +1952,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           bsplineRegistration->SetOptimizerWeights( optimizerWeights );
           }
 
-        typename BSplineTransformType::Pointer outputBSplineTransform =
-          const_cast<BSplineTransformType *>( bsplineRegistration->GetOutput()->Get() );
+        typename BSplineTransformType::Pointer outputBSplineTransform = bsplineRegistration->GetModifiableTransform();
 
         const std::vector<unsigned int> & size = this->m_TransformMethods[currentStageNumber].m_MeshSizeAtBaseLevel;
 
@@ -2171,8 +2157,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           }
 
         typedef typename VelocityFieldRegistrationType::OutputTransformType OutputTransformType;
-        typename OutputTransformType::Pointer outputTransform =
-          const_cast<OutputTransformType *>( velocityFieldRegistration->GetOutput()->Get() );
+        typename OutputTransformType::Pointer outputTransform = velocityFieldRegistration->GetModifiableTransform();
         for( unsigned int n = 0; n < stageMetricList.size(); n++ )
           {
           velocityFieldRegistration->SetFixedImage( n, preprocessedFixedImagesPerStage[n] );
@@ -2381,8 +2366,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           }
 
         typedef typename VelocityFieldRegistrationType::OutputTransformType OutputTransformType;
-        typename OutputTransformType::Pointer outputTransform =
-          const_cast<OutputTransformType *>( velocityFieldRegistration->GetOutput()->Get() );
+        typename OutputTransformType::Pointer outputTransform = velocityFieldRegistration->GetModifiableTransform();
         for( unsigned int n = 0; n < stageMetricList.size(); n++ )
           {
           velocityFieldRegistration->SetFixedImage( n, preprocessedFixedImagesPerStage[n] );
@@ -2550,8 +2534,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           displacementFieldRegistration->SetOptimizerWeights( optimizerWeights );
           }
 
-        typename DisplacementFieldTransformType::Pointer outputDisplacementFieldTransform =
-          const_cast<DisplacementFieldTransformType *>( displacementFieldRegistration->GetOutput()->Get() );
+        typename DisplacementFieldTransformType::Pointer outputDisplacementFieldTransform = displacementFieldRegistration->GetModifiableTransform();
 
         // Create the transform adaptors
 
@@ -2711,8 +2694,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           displacementFieldRegistration->SetOptimizerWeights( optimizerWeights );
           }
 
-        typename BSplineDisplacementFieldTransformType::Pointer outputDisplacementFieldTransform =
-          const_cast<BSplineDisplacementFieldTransformType *>( displacementFieldRegistration->GetOutput()->Get() );
+        typename BSplineDisplacementFieldTransformType::Pointer outputDisplacementFieldTransform = displacementFieldRegistration->GetModifiableTransform();
 
         // Create the transform adaptors
 
@@ -2885,8 +2867,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           displacementFieldRegistration->SetOptimizerWeights( optimizerWeights );
           }
 
-        typename GaussianDisplacementFieldTransformType::Pointer outputDisplacementFieldTransform =
-          const_cast<GaussianDisplacementFieldTransformType *>( displacementFieldRegistration->GetOutput()->Get() );
+        typename GaussianDisplacementFieldTransformType::Pointer outputDisplacementFieldTransform = displacementFieldRegistration->GetModifiableTransform();
 
         // Create the transform adaptors
 
@@ -3036,8 +3017,7 @@ RegistrationHelper<TComputeType, VImageDimension>
           displacementFieldRegistration->SetOptimizerWeights( optimizerWeights );
           }
 
-        typename BSplineDisplacementFieldTransformType::Pointer outputDisplacementFieldTransform =
-          const_cast<BSplineDisplacementFieldTransformType *>( displacementFieldRegistration->GetOutput()->Get() );
+        typename BSplineDisplacementFieldTransformType::Pointer outputDisplacementFieldTransform = displacementFieldRegistration->GetModifiableTransform();
 
         // Create the transform adaptors
 

--- a/SuperBuild/External_ITKv4.cmake
+++ b/SuperBuild/External_ITKv4.cmake
@@ -124,7 +124,7 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
       ${${proj}_FFTWD_ARGS}
     )
 
-    if( USE_VTK STREQUAL "ON" )	
+    if( USE_VTK STREQUAL "ON" )
       set(${proj}_CMAKE_OPTIONS
       -DBUILD_TESTING:BOOL=OFF
       -DBUILD_EXAMPLES:BOOL=OFF
@@ -138,7 +138,7 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
       -DITK_WRAPPING:BOOL=OFF #${BUILD_SHARED_LIBS} ## HACK:  QUICK CHANGE
       -DModule_MGHIO:BOOL=ON
       -DModule_ITKReview:BOOL=ON
-      -DModule_ITKVtkGlue:BOOL=ON	
+      -DModule_ITKVtkGlue:BOOL=ON
       ${${proj}_DCMTK_ARGS}
       ${${proj}_WRAP_ARGS}
       ${${proj}_FFTWF_ARGS}
@@ -150,7 +150,7 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://itk.org/ITK.git)
   set(${proj}_REPOSITORY "https://github.com/InsightSoftwareConsortium/ITK.git")
-  set(${proj}_GIT_TAG 87dcbb4d9a16b1418369a709f91a258cf9d48ee0)
+  set(${proj}_GIT_TAG 541bb689dfdfe72cadfabaa10bf167d6ddb31049)
   set(ITK_VERSION_ID ITK-4.6)
 
   ExternalProject_Add(${proj}


### PR DESCRIPTION
Based on some new changes to ITKv4, we can avoid using const_cast in
many places in ANTs. Therefore, I updated the ITK tag, and I removed
const_cast from everywhere that it could be avoided.