### PR TITLE
FIX: ComposeMultiTransform always return 1 when argc > 3

### DIFF
--- a/Examples/ComposeMultiTransform.cxx
+++ b/Examples/ComposeMultiTransform.cxx
@@ -451,11 +451,12 @@ private:
         }
         break;
       }
+    return EXIT_SUCCESS;
     }
   else
     {
     std::cout << "Input error!" << std::endl;
+    return EXIT_FAILURE;
     }
-  return EXIT_FAILURE;
 }
 } // namespace ants


### PR DESCRIPTION
`ComposeMultiTransform` always returned 1 which stopped my nipype commandline (No error message was thrown and the result file looks good).

It seems that it always `return EXIT_FAILURE` regardless of the `if( is_parsing_ok )` condition. Could you guys pls double check this fix? Thanks!



