### PR TITLE
ENH: Addition of an install rule for target antsUtilities

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -22,6 +22,11 @@ add_library(antsUtilities STATIC antsUtilities.cxx ../Utilities/ReadWriteData.cx
             antsRegistration2DDouble.cxx antsRegistration2DFloat.cxx
             antsRegistration3DDouble.cxx antsRegistration3DFloat.cxx)
 target_link_libraries(antsUtilities ${ITK_LIBRARIES} )
+install(TARGETS antsUtilities
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+  )
 
 macro(STANDARD_ANTS_BUILD ANTS_FUNCTION_NAME EXTRA_LIBS)
   set( ANTS_FUNCTION_NAME ${ANTS_FUNCTION_NAME} )


### PR DESCRIPTION
When installing ANTs, target antsUtilities was not installed.