### PR TITLE
ENH: Make a member function to simplify use

### DIFF
--- a/Examples/itkantsRegistrationHelper.h
+++ b/Examples/itkantsRegistrationHelper.h
@@ -794,6 +794,10 @@ protected:
   RegistrationHelper();
   virtual ~RegistrationHelper();
 private:
+
+  typename itk::ImageBase<VImageDimension>::Pointer GetShrinkImageOutputInformation(const itk::ImageBase<VImageDimension> * inputImageInformation,
+                                const RegistrationHelper<TComputeType, VImageDimension>::ShrinkFactorsPerDimensionContainerType &shrinkFactorsPerDimensionForCurrentLevel) const;
+
   int ValidateParameters();
 
   std::ostream & Logger() const


### PR DESCRIPTION
GetShrinkImageOutputInformation provides a consistent way to compute the
outputImage space for each level of a registration in a consistent way.
By always using the same reference image, we can ensure that the same
shrink results always are produced.