### PR TITLE
Add support for writing output in minc-style .xfm  files

### DIFF
--- a/Examples/antsRegistration.cxx
+++ b/Examples/antsRegistration.cxx
@@ -473,6 +473,16 @@ static void antsRegistrationInitializeCommandLineOptions( itk::ants::CommandLine
   }
 
   {
+  std::string description = std::string( "Use MINC file formats for transformations." );
+
+  OptionType::Pointer option = OptionType::New();
+  option->SetLongName( "minc" );
+  option->SetDescription( description );
+  option->AddFunction( std::string( "0" ) );
+  parser->AddOption( option );
+  }
+
+  {
   std::string description = std::string( "Verbose output." );
 
   OptionType::Pointer option = OptionType::New();

--- a/Examples/antsRegistrationTemplateHeader.cxx
+++ b/Examples/antsRegistrationTemplateHeader.cxx
@@ -2,7 +2,7 @@
 
 namespace ants{
 const char *
-RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVelocityField)
+RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVelocityField, bool minc)
 {
   std::string str(type);
 
@@ -36,20 +36,32 @@ RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVel
 
   if( str == "rigid" )
     {
-    return "Rigid.mat";
+      if(minc)
+        return "Rigid.xfm";
+      else
+        return "Rigid.mat";
     }
   else if( str == "affine" ||
            str == "compositeaffine" || str == "compaff" )
     {
-    return "Affine.mat";
+    if(minc)
+      return "Affine.xfm";
+    else
+      return "Affine.mat";
     }
   else if( str == "similarity" )
     {
-    return "Similarity.mat";
+    if(minc)
+      return "Similarity.xfm";
+    else
+      return "Similarity.mat";
     }
   else if( str == "translation" )
     {
-    return "Translation.mat";
+    if(minc)
+      return "Translation.xfm";
+    else
+      return "Translation.mat";
     }
   else if( str == "bspline" ||
            str == "ffd" )
@@ -58,7 +70,10 @@ RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVel
     }
   else if( str == "genericaffine" )
     {
-    return "GenericAffine.mat";
+    if(minc)
+      return "GenericAffine.xfm";
+    else
+      return "GenericAffine.mat";
     }
   else if( str == "gaussiandisplacementfield" ||
            str == "gdf" ||
@@ -75,7 +90,10 @@ RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVel
            str == "exponential" ||
            str == "bsplineexponential" )
     {
-    return "Warp.nii.gz";
+      if(minc)
+      return ".xfm";
+    else
+      return "Warp.nii.gz";
     }
   return "BOGUS.XXXX";
 }

--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -216,7 +216,7 @@ DoRegistration(typename ParserType::Pointer & parser)
       for( unsigned int n = 0; n < isDerivedInitialFixedTransform.size(); n++ )
         {
         std::stringstream curFileName;
-        curFileName << outputPrefix << n << (use_minc_format?"DerivedInitialFixedTranslation.xfm"?"DerivedInitialFixedTranslation.mat");
+        curFileName << outputPrefix << n << (use_minc_format?"DerivedInitialFixedTranslation.xfm":"DerivedInitialFixedTranslation.mat");
 
         typename RegistrationHelperType::CompositeTransformType::TransformTypePointer curTransform =
           compositeTransform->GetNthTransform( n );

--- a/ImageRegistration/itkANTSImageTransformation.cxx
+++ b/ImageRegistration/itkANTSImageTransformation.cxx
@@ -29,6 +29,7 @@
 #include "itkRecursiveGaussianImageFilter.h"
 #include "itkResampleImageFilter.h"
 #include "itkTransformFileWriter.h"
+#include "itkDisplacementFieldTransform.h"
 
 #include "vnl/vnl_math.h"
 
@@ -73,6 +74,9 @@ ANTSImageTransformation<TDimension, TReal>
     filePrefix = std::string( filePrefix, 0, pos );
     extension = std::string( this->m_NamingConvention, pos,
                              this->m_NamingConvention.length() - 1 );
+    if( extension != std::string( ".xfm" ) )
+    {
+
     if( extension == std::string( ".gz" ) )
       {
       gzExtension = std::string( ".gz" );
@@ -81,7 +85,6 @@ ANTSImageTransformation<TDimension, TReal>
                                filePrefix.length() - 1 );
       filePrefix = std::string( filePrefix, 0, pos );
       }
-
     // GetSupportedWriteExtensions
     typedef itk::ImageIOBase                           IOBaseType;
     typedef std::list<itk::LightObject::Pointer>       ArrayOfImageIOType;
@@ -102,7 +105,7 @@ ANTSImageTransformation<TDimension, TReal>
         while( writeItr != writeExtensions.end() )
           {
           std::string test_ext = *writeItr;
-          //        std::cout <<" compare " << extension << " to " << test_ext << std::endl;
+          //  std::cout <<" compare " << extension << " to " << test_ext << std::endl;
           if( extension == test_ext )
             {
             is_supported = true;
@@ -116,46 +119,62 @@ ANTSImageTransformation<TDimension, TReal>
 
     if( !is_supported )
       {
-      std::cout << " WARNING! we are guessing you want .mnc for your image output instead of: " << extension
+      std::cout << " WARNING! we are guessing you want .nii.gz for your image output instead of: " << extension
                        << std::endl;
       filePrefix = this->m_NamingConvention;
-      extension = std::string(".mnc");
+      extension = std::string(".nii.gz");
       }
+    }
     }
   else
     {
-    extension = std::string( ".mnc" );
+    extension = std::string( ".nii.gz" );
     }
     
-  if( extension==std::string( ".xfm") )
+  if( extension == std::string( ".xfm") )
     {
+
+      typedef itk::DisplacementFieldTransform<TReal,TDimension>          DisplacementFieldTransform;
+      typedef typename DisplacementFieldTransform::DisplacementFieldType DisplacementFieldType;
+      
+      itk::TransformFactory< itk::DisplacementFieldTransform<TReal,TDimension> >::RegisterTransform ();
+      itk::TransformFactory< itk::MatrixOffsetTransformBase<TReal,TDimension,TDimension> >::RegisterTransform ();
       
       std::string fw_filename = filePrefix + extension;
       std::string bw_filename = filePrefix + "_inverse" + extension;
       
       //using ITKv4 functionality to write transforms
-      typedef itk::TransformFileWriterTemplate<float> TransformFileWriterFloat;
+      typedef itk::TransformFileWriterTemplate<TReal> TransformFileWriterFloat;
       
-      TransformFileWriterFloat::Pointer fw_writer=TransformFileWriterFloat::New();
+      typename TransformFileWriterFloat::Pointer fw_writer=TransformFileWriterFloat::New();
       
       if( this->m_AffineTransform )
         fw_writer->AddTransform(this->m_AffineTransform);
       if(this->m_DisplacementField)
-        fw_writer->AddTransform(this->m_DisplacementField);
+      {
+        typename DisplacementFieldTransform::Pointer disp = DisplacementFieldTransform::New();
+        disp->SetDisplacementField(this->m_DisplacementField);
+        fw_writer->AddTransform(disp);
+      }
       
       fw_writer->SetFileName(fw_filename);
       fw_writer->Update();
       
-      TransformFileWriterFloat::Pointer bw_writer=TransformFileWriterFloat::New();
+      typename TransformFileWriterFloat::Pointer bw_writer=TransformFileWriterFloat::New();
       
       if(this->m_InverseDisplacementField)
-        bw_writer->AddTransform(this->m_InverseDisplacementField);
+      {
+        typename DisplacementFieldTransform::Pointer disp = DisplacementFieldTransform::New();
+        disp->SetDisplacementField(this->m_InverseDisplacementField);
+
+        bw_writer->AddTransform(disp);
+      }
       
       typename AffineTransformType::Pointer tmp=AffineTransformType::New();
-      
       if( this->m_AffineTransform )
       {
         this->m_AffineTransform->GetInverse(tmp);
+
         bw_writer->AddTransform(tmp);
       }
       

--- a/Utilities/itkantsReadWriteTransform.h
+++ b/Utilities/itkantsReadWriteTransform.h
@@ -42,6 +42,7 @@ ReadTransform(const std::string & filename,
       && filename.find(".hdf4") == std::string::npos
       && filename.find(".mat") == std::string::npos
       && filename.find(".txt") == std::string::npos
+      && filename.find(".xfm") == std::string::npos
       )
     {
     try

--- a/Utilities/itkantsReadWriteTransform.h
+++ b/Utilities/itkantsReadWriteTransform.h
@@ -33,6 +33,7 @@ ReadTransform(const std::string & filename,
   typedef typename DisplacementFieldTransformType::DisplacementFieldType    DisplacementFieldType;
   typedef itk::ImageFileReader<DisplacementFieldType>                       DisplacementFieldReaderType;
   typename DisplacementFieldReaderType::Pointer fieldReader = DisplacementFieldReaderType::New();
+  typedef typename itk::CompositeTransform<T, VImageDimension> CompositeTransformType;
 
   // There are known tranform type extentions that should not be considered as imaging files
   // That would be used as deformatino feilds
@@ -99,7 +100,21 @@ ReadTransform(const std::string & filename,
 
     const typename itk::TransformFileReaderTemplate<T>::TransformListType * const listOfTransforms =
       transformReader->GetTransformList();
-    transform = dynamic_cast<TransformType *>( listOfTransforms->front().GetPointer() );
+    
+    if(listOfTransforms->size()>1)
+    {
+      typename CompositeTransformType::Pointer comp_transform=CompositeTransformType::New();
+      for(typename itk::TransformFileReaderTemplate<T>::TransformListType::const_iterator i=listOfTransforms->begin();
+          i!=listOfTransforms->end();
+          ++i)
+          {
+            comp_transform->AddTransform( dynamic_cast<TransformType *>(i->GetPointer()) );
+          }
+      transform = dynamic_cast<TransformType *>(comp_transform.GetPointer());
+    } else {
+    
+      transform = dynamic_cast<TransformType *>( listOfTransforms->front().GetPointer() );
+    }
 
     /** below is a bad thing but it's the only temporary fix i could find for ANTsR on unix --- B.A. */
     if ( transform.IsNull() && ( useStaticCastForR == true ) )


### PR DESCRIPTION
Added support for writing .xfm files to ANTS and  antsRegistration binaries. 
antsRegistration will have --minc option to make it produce .xfm files as output. 

