### PR TITLE
Fixed writing transformations

### DIFF
--- a/Examples/antsRegistrationTemplateHeader.cxx
+++ b/Examples/antsRegistrationTemplateHeader.cxx
@@ -86,8 +86,8 @@ RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVel
            str == "symmetricnormalization" ||
            str == "bsplinesyn" )
     {
-      if(minc)
-      return ".xfm";
+    if(minc)
+      return "_NL.xfm";
     else
       return "Warp.nii.gz";
     } 
@@ -99,7 +99,7 @@ RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVel
            str == "exponential" ||
            str == "bsplineexponential" )
     {
-      if(minc)
+    if(minc)
       return "_Warp.mnc";
     else
       return "Warp.nii.gz";

--- a/Examples/antsRegistrationTemplateHeader.cxx
+++ b/Examples/antsRegistrationTemplateHeader.cxx
@@ -37,7 +37,7 @@ RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVel
   if( str == "rigid" )
     {
       if(minc)
-        return "Rigid.xfm";
+        return "_Rigid.xfm";
       else
         return "Rigid.mat";
     }
@@ -45,33 +45,36 @@ RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVel
            str == "compositeaffine" || str == "compaff" )
     {
     if(minc)
-      return "Affine.xfm";
+      return "_Affine.xfm";
     else
       return "Affine.mat";
     }
   else if( str == "similarity" )
     {
     if(minc)
-      return "Similarity.xfm";
+      return "_Similarity.xfm";
     else
       return "Similarity.mat";
     }
   else if( str == "translation" )
     {
     if(minc)
-      return "Translation.xfm";
+      return "_Translation.xfm";
     else
       return "Translation.mat";
     }
   else if( str == "bspline" ||
            str == "ffd" )
     {
-    return "BSpline.txt";
+    if(minc)
+      return "_BSpline.txt";
+    else
+      return "BSpline.txt";
     }
   else if( str == "genericaffine" )
     {
     if(minc)
-      return "GenericAffine.xfm";
+      return "_GenericAffine.xfm";
     else
       return "GenericAffine.mat";
     }
@@ -81,8 +84,14 @@ RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVel
            str == "dmffd" ||
            str == "syn" ||
            str == "symmetricnormalization" ||
-           str == "bsplinesyn" ||
-           str == "timevaryingvelocityfield" ||
+           str == "bsplinesyn" )
+    {
+      if(minc)
+      return ".xfm";
+    else
+      return "Warp.nii.gz";
+    } 
+  else if( str == "timevaryingvelocityfield" ||
            str == "tvf" ||
            str == "timevaryingbsplinevelocityfield" ||
            str == "tvdmffd" ||
@@ -91,7 +100,7 @@ RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVel
            str == "bsplineexponential" )
     {
       if(minc)
-      return ".xfm";
+      return "_Warp.mnc";
     else
       return "Warp.nii.gz";
     }

--- a/Examples/antsRegistrationTemplateHeader.cxx
+++ b/Examples/antsRegistrationTemplateHeader.cxx
@@ -25,7 +25,11 @@ RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVel
     }
 
   if( str == "timevaryingvelocityfield" ||
-      str == "tvf" )
+      str == "tvf" ||
+      str == "exp" ||
+      str == "exponential" ||
+      str == "bsplineexponential"
+    )
     {
     writeVelocityField = true;
     }
@@ -84,20 +88,20 @@ RegTypeToFileName(const std::string & type, bool & writeInverse, bool & writeVel
            str == "dmffd" ||
            str == "syn" ||
            str == "symmetricnormalization" ||
-           str == "bsplinesyn" )
+           str == "bsplinesyn" ||
+           str == "exp" ||
+           str == "exponential" ||
+           str == "bsplineexponential" )
     {
     if(minc)
       return "_NL.xfm";
     else
       return "Warp.nii.gz";
-    } 
+    }
   else if( str == "timevaryingvelocityfield" ||
            str == "tvf" ||
            str == "timevaryingbsplinevelocityfield" ||
-           str == "tvdmffd" ||
-           str == "exp" ||
-           str == "exponential" ||
-           str == "bsplineexponential" )
+           str == "tvdmffd"  )
     {
     if(minc)
       return "_Warp.mnc";

--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -1326,7 +1326,6 @@ DoRegistration(typename ParserType::Pointer & parser)
         // return value.
         itk::ants::WriteTransform<TComputeType, VImageDimension>( curTransform, curFileName.str() );
 
-        typedef typename DisplacementFieldTransformType::DisplacementFieldType  DisplacementFieldType;
         typename DisplacementFieldTransformType::Pointer dispTransform =
           dynamic_cast<DisplacementFieldTransformType *>(curTransform.GetPointer() );
         if( writeInverse && dispTransform.IsNotNull() )

--- a/Examples/antsRegistrationTemplateHeader.h
+++ b/Examples/antsRegistrationTemplateHeader.h
@@ -1329,32 +1329,12 @@ DoRegistration(typename ParserType::Pointer & parser)
         typedef typename DisplacementFieldTransformType::DisplacementFieldType  DisplacementFieldType;
         typename DisplacementFieldTransformType::Pointer dispTransform =
           dynamic_cast<DisplacementFieldTransformType *>(curTransform.GetPointer() );
-        // write inverse transform file
         if( writeInverse && dispTransform.IsNotNull() )
           {
-          typename DisplacementFieldType::ConstPointer inverseDispField = dispTransform->GetInverseDisplacementField();
-          if( inverseDispField.IsNotNull() )
-            {
-            std::stringstream curInverseFileName;
-            curInverseFileName << outputPrefix << i << (use_minc_format?"_inverse.xfm":"InverseWarp.nii.gz");
-            typedef itk::ImageFileWriter<DisplacementFieldType> InverseWriterType;
-            typename InverseWriterType::Pointer inverseWriter = InverseWriterType::New();
-            inverseWriter->SetInput( dispTransform->GetInverseDisplacementField() );
-            inverseWriter->SetFileName( curInverseFileName.str().c_str() );
-            try
-              {
-              inverseWriter->Update();
-              }
-            catch( itk::ExceptionObject & err )
-              {
-              if( verbose )
-                {
-                std::cerr << "Can't write transform file " << curInverseFileName.str().c_str() << std::endl;
-                std::cerr << "Exception Object caught: " << std::endl;
-                std::cerr << err << std::endl;
-                }
-              }
-            }
+          std::stringstream curInverseFileName;
+          curInverseFileName << outputPrefix << i << (use_minc_format?"_inverse":"Inverse") << transformTemplateName;
+          // write inverse transform file
+          itk::ants::WriteInverseTransform<TComputeType, VImageDimension>( dispTransform, curInverseFileName.str() );
           }
         if( writeVelocityField )
           {
@@ -1368,7 +1348,7 @@ DoRegistration(typename ParserType::Pointer & parser)
           if( !velocityFieldTransform.IsNull() )
             {
             std::stringstream curVelocityFieldFileName;
-            curVelocityFieldFileName << outputPrefix << i << (use_minc_format?"VelocityField.mnc":"VelocityField.nii.gz");
+            curVelocityFieldFileName << outputPrefix << i << (use_minc_format?"_VelocityField.mnc":"VelocityField.nii.gz");
 
             typedef itk::ImageFileWriter<VelocityFieldType> VelocityFieldWriterType;
             typename VelocityFieldWriterType::Pointer velocityFieldWriter = VelocityFieldWriterType::New();

--- a/Utilities/itkantsReadWriteTransform.h
+++ b/Utilities/itkantsReadWriteTransform.h
@@ -203,7 +203,7 @@ WriteInverseTransform(typename itk::DisplacementFieldTransform<T, VImageDimensio
       typename DisplacementFieldTransformType::Pointer inv_xfrm=DisplacementFieldTransformType::New();
       inv_xfrm->SetDisplacementField(inverseDispField);
       typename TransformWriterType::Pointer transformWriter = TransformWriterType::New();
-      transformWriter->SetInput(xfrm);
+      transformWriter->SetInput(inv_xfrm);
       transformWriter->SetFileName(filename.c_str() );
       transformWriter->Update();
       }


### PR DESCRIPTION
1. Fixed writing transformations per stage in minc-style .xfm files
2. Fixed output in case of unsupported transformation type, fixes stnava/ANTs#207
3. Changed transformation type to DisplacementFieldTransform for all non-linear transforms when writing individually or as composite 