### PR TITLE
Added support for the SLURM cluster resource manager

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -207,6 +207,7 @@ install(PROGRAMS ../Scripts/ANTSpexec.sh
      ../Scripts/waitForPBSQJobs.pl
      ../Scripts/waitForSGEQJobs.pl
      ../Scripts/waitForXGridJobs.pl
+     ../Scripts/waitForSlurmJobs.pl
                 DESTINATION bin
                 PERMISSIONS  OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
                 CONFIGURATIONS  Release

--- a/Scripts/antsJointLabelFusion.sh
+++ b/Scripts/antsJointLabelFusion.sh
@@ -945,6 +945,9 @@ if [[ $DOQSUB -eq 5 ]];
         exit 1;
       fi
 
+    # Remove the SLURM output files (which are likely to be empty)
+    rm -f ${OUTPUT_DIR}/slurm-*.out
+
     EXISTING_WARPED_ATLAS_IMAGES=()
     EXISTING_WARPED_ATLAS_LABELS=()
     for (( i = 0; i < ${#WARPED_ATLAS_IMAGES[@]}; i++ ))

--- a/Scripts/antsJointLabelFusion.sh
+++ b/Scripts/antsJointLabelFusion.sh
@@ -43,9 +43,10 @@ PEXEC=${ANTSPATH}ANTSpexec.sh
 SGE=${ANTSPATH}waitForSGEQJobs.pl
 PBS=${ANTSPATH}waitForPBSQJobs.pl
 XGRID=${ANTSPATH}waitForXGridJobs.pl
+SLURM=${ANTSPATH}/waitForSlurmJobs.pl
 
 fle_error=0
-for FLE in $JLF $ANTS $WARP $PEXEC $SGE $XGRID $PBS
+for FLE in $JLF $ANTS $WARP $PEXEC $SGE $XGRID $PBS $SLURM
   do
   if [[ ! -x $FLE ]];
     then
@@ -93,7 +94,7 @@ Optional arguments:
      -k:  Keep files:     Keep warped atlas and label files (default = 0).
 
      -c:  Control for parallel computation (default 0) -- 0 == run serially,  1 == SGE qsub,
-          2 == use PEXEC (localhost), 3 == Apple XGrid, 4 == PBS qsub.
+          2 == use PEXEC (localhost), 3 == Apple XGrid, 4 == PBS qsub, 5 == SLURM.
 
      -j: Number of cpu cores to use (default 2; -- requires "-c 2").
 
@@ -175,7 +176,7 @@ Optional arguments:
      -k:  Keep files:     Keep warped atlas and label files (default = 0).
 
      -c:  Control for parallel computation (default 0) -- 0 == run serially,  1 == SGE qsub,
-          2 == use PEXEC (localhost), 3 == Apple XGrid, 4 == PBS qsub.
+          2 == use PEXEC (localhost), 3 == Apple XGrid, 4 == PBS qsub, 5 == SLURM.
 
      -j: Number of cpu cores to use (default 2; -- requires "-c 2").
 
@@ -199,6 +200,7 @@ will terminate prematurely if these files are not present or are not executable.
 - waitForPBSQJobs.pl  (only for use with Portable Batch System)
 - ANTSpexec.sh (only for use with localhost parallel execution)
 - waitForXGridJobs.pl (only for use with Apple XGrid)
+- waitForSlurmJobs.pl (only for use with SLURM)
 - antsRegistrationSyN.sh
 - antsRegistrationSyNQuick.sh ( quick parameters )
 
@@ -336,9 +338,9 @@ while getopts "c:d:f:g:h:j:k:l:m:o:p:t:q:x:z:" OPT
    ;;
       c) #use SGE cluster
    DOQSUB=$OPTARG
-   if [[ $DOQSUB -gt 4 ]];
+   if [[ $DOQSUB -gt 5 ]];
      then
-       echo " DOQSUB must be an integer value (0=serial, 1=SGE qsub, 2=try pexec, 3=XGrid, 4=PBS qsub ) you passed  -c $DOQSUB "
+       echo " DOQSUB must be an integer value (0=serial, 1=SGE qsub, 2=try pexec, 3=XGrid, 4=PBS qsub, 5=SLURM ) you passed  -c $DOQSUB "
        exit 1
      fi
    ;;
@@ -401,6 +403,15 @@ if [[ $DOQSUB -eq 1 || $DOQSUB -eq 4 ]];
       then
         echo "do you have qsub?  if not, then choose another c option ... if so, then check where the qsub alias points ..."
         exit 1
+      fi
+  fi
+if [[ $DOQSUB -eq 5 ]];
+  then
+    qq=`which sbatch`
+    if [[ ${#qq} -lt 1 ]];
+      then
+        echo "do you have sbatch?  if not, then choose another c option ... if so, then check where the sbatch alias points ..."
+        exit
       fi
   fi
 
@@ -490,7 +501,15 @@ for (( i = 0; i < ${#ATLAS_IMAGES[@]}; i++ ))
                           -t ${OUTPUT_PREFIX}${BASENAME}_${i}_1Warp.nii.gz \
                           -t ${OUTPUT_PREFIX}${BASENAME}_${i}_0GenericAffine.mat >> ${OUTPUT_PREFIX}${BASENAME}_${i}_log.txt"
 
-    echo "$registrationCall" > $qscript
+    rm -f $qscript
+
+    if [[ $DOQSUB -eq 5 ]];
+      then
+        # SLURM job scripts must start with a shebang
+        echo '#!/bin/sh' > $qscript
+      fi
+
+    echo "$registrationCall" >> $qscript
     echo "$labelXfrmCall" >> $qscript
 
     if [[ $DOQSUB -eq 1 ]];
@@ -507,6 +526,11 @@ for (( i = 0; i < ${#ATLAS_IMAGES[@]}; i++ ))
       then
         id=`xgrid $XGRID_OPTS -job submit /bin/bash $qscript | awk '{sub(/;/,"");print $3}' | tr '\n' ' ' | sed 's:  *: :g'`
         jobIDs="$jobIDs $id"
+    elif [[ $DOQSUB -eq 5 ]];
+      then
+        id=`sbatch --job-name=antsJlfReg --export=ANTSPATH=$ANTSPATH $QSUBOPTS --nodes=1 --cpus-per-task=1 --time=20:00:00 --mem=8192M $qscript | rev | cut -f1 -d\ | rev`
+        jobIDs="$jobIDs $id"
+        sleep 0.5
     elif [[ $DOQSUB -eq 0 ]];
       then
         echo $qscript
@@ -904,6 +928,83 @@ if [[ $DOQSUB -eq 3 ]];
     echo "$jlfCall" > $qscript2
 
     sh $qscript2
+  fi
+if [[ $DOQSUB -eq 5 ]];
+  then
+    # Run jobs on SLURM and wait to finish
+    echo
+    echo "--------------------------------------------------------------------------------------"
+    echo " Starting JLF on SLURM cluster. "
+    echo "--------------------------------------------------------------------------------------"
+
+    ${ANTSPATH}/waitForSlurmJobs.pl 1 600 $jobIDs
+    # Returns 1 if there are errors
+    if [[ ! $? -eq 0 ]];
+      then
+        echo "SLURM submission failed - jobs went into error state"
+        exit 1;
+      fi
+
+    EXISTING_WARPED_ATLAS_IMAGES=()
+    EXISTING_WARPED_ATLAS_LABELS=()
+    for (( i = 0; i < ${#WARPED_ATLAS_IMAGES[@]}; i++ ))
+      do
+        echo ${WARPED_ATLAS_IMAGES[$i]}
+        if [[ -f ${WARPED_ATLAS_IMAGES[$i]} ]] && [[ -f ${WARPED_ATLAS_LABELS[$i]} ]];
+          then
+            if [[ -f ${TARGET_MASK_IMAGE} ]];
+              then
+                TMP_WARPED_ATLAS_LABEL_MASK=${OUTPUT_PREFIX}WarpedAtlasLabelMask.nii.gz
+                ${ANTSPATH}/ThresholdImage ${DIM} ${WARPED_ATLAS_LABELS[$i]} ${TMP_WARPED_ATLAS_LABEL_MASK} 0 0 0 1
+
+                OVERLAP_MEASURES=( `${ANTSPATH}/LabelOverlapMeasures ${DIM} ${TMP_WARPED_ATLAS_LABEL_MASK} ${TARGET_MASK_IMAGE} 1` )
+                TOKENS=( ${OVERLAP_MEASURES[1]//,/\ } )
+                DICE_OVERLAP=${TOKENS[3]}
+
+                if (( $(echo "${DICE_OVERLAP} >= ${DICE_THRESHOLD}" | bc -l) ));
+                  then
+                    EXISTING_WARPED_ATLAS_IMAGES[${#EXISTING_WARPED_ATLAS_IMAGES[@]}]=${WARPED_ATLAS_IMAGES[$i]}
+                    EXISTING_WARPED_ATLAS_LABELS[${#EXISTING_WARPED_ATLAS_LABELS[@]}]=${WARPED_ATLAS_LABELS[$i]}
+                  else
+                    echo Not including ${WARPED_ATLAS_IMAGES[$i]} \(Dice = ${DICE_OVERLAP}\)
+                  fi
+
+                rm -f $TMP_WARPED_ATLAS_LABEL_MASK
+              else
+                EXISTING_WARPED_ATLAS_IMAGES[${#EXISTING_WARPED_ATLAS_IMAGES[@]}]=${WARPED_ATLAS_IMAGES[$i]}
+                EXISTING_WARPED_ATLAS_LABELS[${#EXISTING_WARPED_ATLAS_LABELS[@]}]=${WARPED_ATLAS_LABELS[$i]}
+              fi
+          fi
+      done
+
+    if [[ ${#EXISTING_WARPED_ATLAS_LABELS[@]} -lt 2 ]];
+      then
+        echo "Error:  At least 3 warped image/label pairs needs to exist for jointFusion."
+        exit 1
+      fi
+    if [[ ${#EXISTING_WARPED_ATLAS_LABELS[@]} -ne ${#WARPED_ATLAS_LABELS[@]} ]];
+      then
+        echo "Warning:  One or more registrations failed."
+      fi
+
+    for (( i = 0; i < ${#EXISTING_WARPED_ATLAS_IMAGES[@]}; i++ ))
+      do
+        jlfCall="${jlfCall} -g ${EXISTING_WARPED_ATLAS_IMAGES[$i]} -l ${EXISTING_WARPED_ATLAS_LABELS[$i]}"
+      done
+
+    if [[ -z "${OUTPUT_POSTERIORS_FORMAT}" ]];
+      then
+        jlfCall="${jlfCall} -o [${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz]"
+      else
+        jlfCall="${jlfCall} -r 1 -o [${OUTPUT_PREFIX}Labels.nii.gz,${OUTPUT_PREFIX}Intensity.nii.gz,${OUTPUT_POSTERIORS_FORMAT}]"
+      fi
+
+    qscript2="${OUTPUT_PREFIX}JLF.sh"
+    echo "#!/bin/sh" > $qscript2
+    echo "$jlfCall" >> $qscript2
+
+    jobIDs=`sbatch --job-name=antsJlf --export=ANTSPATH=$ANTSPATH $QSUBOPTS --nodes=1 --cpus-per-task=1 --time=30:00:00 --mem=8192M $qscript2 | rev | cut -f1 -d\ | rev`
+    ${ANTSPATH}/waitForSlurmJobs.pl 1 600 $jobIDs
   fi
 
 # clean up

--- a/Scripts/antsJointLabelFusion.sh
+++ b/Scripts/antsJointLabelFusion.sh
@@ -528,7 +528,7 @@ for (( i = 0; i < ${#ATLAS_IMAGES[@]}; i++ ))
         jobIDs="$jobIDs $id"
     elif [[ $DOQSUB -eq 5 ]];
       then
-        id=`sbatch --job-name=antsJlfReg --export=ANTSPATH=$ANTSPATH $QSUBOPTS --nodes=1 --cpus-per-task=1 --time=20:00:00 --mem=8192M $qscript | rev | cut -f1 -d\ | rev`
+        id=`sbatch --job-name=antsJlfReg${i} --export=ANTSPATH=$ANTSPATH $QSUBOPTS --nodes=1 --cpus-per-task=1 --time=20:00:00 --mem=8192M $qscript | rev | cut -f1 -d\ | rev`
         jobIDs="$jobIDs $id"
         sleep 0.5
     elif [[ $DOQSUB -eq 0 ]];
@@ -1022,6 +1022,7 @@ if [[ $KEEP_ALL_IMAGES -eq 0 ]];
     rm -f ${INVERSE_WARP_FIELDS[@]}
     rm -f $qscript
     rm -f $qscript2
+    rm -f ${OUTPUT_DIR}/slurm-*.out
   fi
 
 time_end=`date +%s`

--- a/Scripts/antsMalfLabeling.sh
+++ b/Scripts/antsMalfLabeling.sh
@@ -43,9 +43,10 @@ PEXEC=${ANTSPATH}ANTSpexec.sh
 SGE=${ANTSPATH}waitForSGEQJobs.pl
 PBS=${ANTSPATH}waitForPBSQJobs.pl
 XGRID=${ANTSPATH}waitForXGridJobs.pl
+SLURM=${ANTSPATH}/waitForSlurmJobs.pl
 
 fle_error=0
-for FLE in $MALF $ANTS $WARP $PEXEC $SGE $XGRID $PBS
+for FLE in $MALF $ANTS $WARP $PEXEC $SGE $XGRID $PBS $SLURM
   do
   if [[ ! -x $FLE ]];
     then
@@ -93,7 +94,7 @@ Optional arguments:
      -k:  Keep files:     Keep warped atlas and label files (default = 0).
 
      -c:  Control for parallel computation (default 0) -- 0 == run serially,  1 == SGE qsub,
-          2 == use PEXEC (localhost), 3 == Apple XGrid, 4 == PBS qsub.
+          2 == use PEXEC (localhost), 3 == Apple XGrid, 4 == PBS qsub, 5 == SLURM.
 
      -j: Number of cpu cores to use (default 2; -- requires "-c 2").
 
@@ -175,7 +176,7 @@ Optional arguments:
      -k:  Keep files:     Keep warped atlas and label files (default = 0).
 
      -c:  Control for parallel computation (default 0) -- 0 == run serially,  1 == SGE qsub,
-          2 == use PEXEC (localhost), 3 == Apple XGrid, 4 == PBS qsub.
+          2 == use PEXEC (localhost), 3 == Apple XGrid, 4 == PBS qsub, 5 == SLURM.
 
      -j: Number of cpu cores to use (default 2; -- requires "-c 2").
 
@@ -199,6 +200,7 @@ will terminate prematurely if these files are not present or are not executable.
 - waitForPBSQJobs.pl  (only for use with Portable Batch System)
 - ANTSpexec.sh (only for use with localhost parallel execution)
 - waitForXGridJobs.pl (only for use with Apple XGrid)
+- waitForSlurmJobs.pl (only for use with SLURM)
 - antsRegistrationSyN.sh
 - antsRegistrationSyNQuick.sh ( quick parameters )
 
@@ -350,9 +352,9 @@ while getopts "c:d:f:g:h:j:k:l:m:o:p:t:q:x:z:" OPT
    ;;
       c) #use SGE cluster
    DOQSUB=$OPTARG
-   if [[ $DOQSUB -gt 4 ]];
+   if [[ $DOQSUB -gt 5 ]];
      then
-       echo " DOQSUB must be an integer value (0=serial, 1=SGE qsub, 2=try pexec, 3=XGrid, 4=PBS qsub ) you passed  -c $DOQSUB "
+       echo " DOQSUB must be an integer value (0=serial, 1=SGE qsub, 2=try pexec, 3=XGrid, 4=PBS qsub, 5=SLURM ) you passed  -c $DOQSUB "
        exit 1
      fi
    ;;
@@ -415,6 +417,15 @@ if [[ $DOQSUB -eq 1 || $DOQSUB -eq 4 ]];
       then
         echo "do you have qsub?  if not, then choose another c option ... if so, then check where the qsub alias points ..."
         exit 1
+      fi
+  fi
+if [[ $DOQSUB -eq 5 ]];
+  then
+    qq=`which sbatch`
+    if [[ ${#qq} -lt 1 ]];
+      then
+        echo "do you have sbatch?  if not, then choose another c option ... if so, then check where the sbatch alias points ..."
+        exit
       fi
   fi
 
@@ -504,7 +515,15 @@ for (( i = 0; i < ${#ATLAS_IMAGES[@]}; i++ ))
                           -t ${OUTPUT_PREFIX}${BASENAME}_${i}_1Warp.nii.gz \
                           -t ${OUTPUT_PREFIX}${BASENAME}_${i}_0GenericAffine.mat >> ${OUTPUT_PREFIX}${BASENAME}_${i}_log.txt"
 
-    echo "$registrationCall" > $qscript
+    rm -f $qscript
+
+    if [[ $DOQSUB -eq 5 ]];
+      then
+        # SLURM job scripts must start with a shebang
+        echo '#!/bin/sh' > $qscript
+      fi
+
+    echo "$registrationCall" >> $qscript
     echo "$labelXfrmCall" >> $qscript
 
     if [[ $DOQSUB -eq 1 ]];
@@ -521,6 +540,11 @@ for (( i = 0; i < ${#ATLAS_IMAGES[@]}; i++ ))
       then
         id=`xgrid $XGRID_OPTS -job submit /bin/bash $qscript | awk '{sub(/;/,"");print $3}' | tr '\n' ' ' | sed 's:  *: :g'`
         jobIDs="$jobIDs $id"
+    elif [[ $DOQSUB -eq 5 ]];
+      then
+        id=`sbatch --job-name=antsMalfReg${i} --export=ANTSPATH=$ANTSPATH $QSUBOPTS --nodes=1 --cpus-per-task=1 --time=20:00:00 --mem=8192M $qscript | rev | cut -f1 -d\ | rev`
+        jobIDs="$jobIDs $id"
+        sleep 0.5
     elif [[ $DOQSUB -eq 0 ]];
       then
         echo $qscript
@@ -877,6 +901,81 @@ if [[ $DOQSUB -eq 3 ]];
     echo "$malfCall" > $qscript2
 
     sh $qscript2
+  fi
+if [[ $DOQSUB -eq 5 ]];
+  then
+    # Run jobs on SLURM and wait to finish
+    echo
+    echo "--------------------------------------------------------------------------------------"
+    echo " Starting MALF on SLURM cluster. "
+    echo "--------------------------------------------------------------------------------------"
+
+    ${ANTSPATH}/waitForSlurmJobs.pl 1 600 $jobIDs
+    # Returns 1 if there are errors
+    if [[ ! $? -eq 0 ]];
+      then
+        echo "SLURM submission failed - jobs went into error state"
+        exit 1;
+      fi
+
+    # Remove the SLURM output files (which are likely to be empty)
+    rm -f ${OUTPUT_DIR}/slurm-*.out
+
+    EXISTING_WARPED_ATLAS_IMAGES=()
+    EXISTING_WARPED_ATLAS_LABELS=()
+    for (( i = 0; i < ${#WARPED_ATLAS_IMAGES[@]}; i++ ))
+      do
+        echo ${WARPED_ATLAS_IMAGES[$i]}
+        if [[ -f ${WARPED_ATLAS_IMAGES[$i]} ]] && [[ -f ${WARPED_ATLAS_LABELS[$i]} ]];
+          then
+            if [[ -f ${TARGET_MASK_IMAGE} ]];
+              then
+                TMP_WARPED_ATLAS_LABEL_MASK=${OUTPUT_PREFIX}WarpedAtlasLabelMask.nii.gz
+                ${ANTSPATH}/ThresholdImage ${DIM} ${WARPED_ATLAS_LABELS[$i]} ${TMP_WARPED_ATLAS_LABEL_MASK} 0 0 0 1
+
+                OVERLAP_MEASURES=( `${ANTSPATH}/LabelOverlapMeasures ${DIM} ${TMP_WARPED_ATLAS_LABEL_MASK} ${TARGET_MASK_IMAGE} 1` )
+                TOKENS=( ${OVERLAP_MEASURES[1]//,/\ } )
+                DICE_OVERLAP=${TOKENS[3]}
+
+                if (( $(echo "${DICE_OVERLAP} >= ${DICE_THRESHOLD}" | bc -l) ));
+                  then
+                    EXISTING_WARPED_ATLAS_IMAGES[${#EXISTING_WARPED_ATLAS_IMAGES[@]}]=${WARPED_ATLAS_IMAGES[$i]}
+                    EXISTING_WARPED_ATLAS_LABELS[${#EXISTING_WARPED_ATLAS_LABELS[@]}]=${WARPED_ATLAS_LABELS[$i]}
+                  else
+                    echo Not including ${WARPED_ATLAS_IMAGES[$i]} \(Dice = ${DICE_OVERLAP}\)
+                  fi
+
+                rm -f $TMP_WARPED_ATLAS_LABEL_MASK
+              else
+                EXISTING_WARPED_ATLAS_IMAGES[${#EXISTING_WARPED_ATLAS_IMAGES[@]}]=${WARPED_ATLAS_IMAGES[$i]}
+                EXISTING_WARPED_ATLAS_LABELS[${#EXISTING_WARPED_ATLAS_LABELS[@]}]=${WARPED_ATLAS_LABELS[$i]}
+              fi
+          fi
+      done
+
+    if [[ ${#EXISTING_WARPED_ATLAS_LABELS[@]} -lt 2 ]];
+      then
+        echo "Error:  At least 3 warped image/label pairs needs to exist for jointFusion."
+        exit 1
+      fi
+    if [[ ${#EXISTING_WARPED_ATLAS_LABELS[@]} -ne ${#WARPED_ATLAS_LABELS[@]} ]];
+      then
+        echo "Warning:  One or more registrations failed."
+      fi
+
+    malfCall="${malfCall} -g ${EXISTING_WARPED_ATLAS_IMAGES[@]} -l ${EXISTING_WARPED_ATLAS_LABELS[@]} ${OUTPUT_PREFIX}MalfLabels.nii.gz"
+
+    if [[ $MAJORITYVOTE -eq 1 ]];
+      then
+        malfCall="${ANTSPATH}/ImageMath ${DIM} ${OUTPUT_PREFIX}MajorityVotingLabels.nii.gz MajorityVoting ${EXISTING_WARPED_ATLAS_LABELS[@]} "
+      fi
+
+    qscript2="${OUTPUT_PREFIX}MALF.sh"
+    echo "#!/bin/sh" > $qscript2
+    echo "$malfCall" >> $qscript2
+
+    jobIDs=`sbatch --job-name=antsMalf --export=ANTSPATH=$ANTSPATH $QSUBOPTS --nodes=1 --cpus-per-task=1 --time=30:00:00 --mem=8192M $qscript2 | rev | cut -f1 -d\ | rev`
+    ${ANTSPATH}/waitForSlurmJobs.pl 1 600 $jobIDs
   fi
 
 # clean up

--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -998,12 +998,14 @@ if [[ "$RIGID" -eq 1 ]];
             rm -f ${outdir}/job_*_qsub.sh
         elif [[ $DOQSUB -eq 5 ]];
           then
-            mv ${outdir}/antsrigid* ${outdir}/rigid/
+            mv ${outdir}/slurm-*.out ${outdir}/rigid/
+            mv ${outdir}/job*.txt ${outdir}/rigid/
+
             # Remove qsub scripts
             rm -f ${outdir}/job_${count}_qsub.sh
         fi
       else
-        rm -f  ${outdir}/rigid*.* ${outdir}/job*.txt
+        rm -f  ${outdir}/rigid*.* ${outdir}/job*.txt ${outdir}/slurm-*.out
       fi
 fi # endif RIGID
 
@@ -1348,7 +1350,8 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
             rm -f ${outdir}/job_*.sh
         elif [[ $DOQSUB -eq 5 ]];
             then
-            mv ${outdir}/antsdef* ${outdir}/${TRANSFORMATIONTYPE}_iteration_${i}
+            mv ${outdir}/slurm-*.out ${outdir}/${TRANSFORMATIONTYPE}_iteration_${i}
+            mv ${outdir}/job*.txt ${outdir}/${TRANSFORMATIONTYPE}_iteration_${i}
         fi
       fi
     ((i++))

--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -1353,6 +1353,8 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
             mv ${outdir}/slurm-*.out ${outdir}/${TRANSFORMATIONTYPE}_iteration_${i}
             mv ${outdir}/job*.txt ${outdir}/${TRANSFORMATIONTYPE}_iteration_${i}
         fi
+      else
+        rm -f ${outdir}/job*.txt ${outdir}/slurm-*.out
       fi
     ((i++))
 done

--- a/Scripts/waitForSlurmJobs.pl
+++ b/Scripts/waitForSlurmJobs.pl
@@ -1,0 +1,129 @@
+#!/usr/bin/perl -w
+
+use strict;
+
+# Usage: waitForSlurmJobs.pl <verbose [1 or 0]> <delay in seconds in range 10-600> [job IDs]
+#
+#
+# Takes as args a string of sbatch job IDs and periodically monitors them. Once they all finish, it returns 0
+#
+# If any of the jobs go into error state, an error is printed to stderr and the program waits for the non-error
+# jobs to finish, then returns 1
+
+my ( $verbose, $delay, @jobIDs ) = @ARGV;
+
+my %COMPLETION_STATES = map {
+    $_ => 1
+} qw( COMPLETED );
+
+my %FAILURE_STATES = map {
+    $_ => 1
+} qw(
+    CANCELLED FAILED NODE_FAIL PREEMPTED TIMEOUT
+    );
+
+# Validate that the delay is within the acceptable range
+if ($delay < 10) {
+    print STDERR "Sleep period is too short, will poll queue once every 10 seconds\n";
+    $delay = 10;
+} elsif ($delay > 3600) {
+    print STDERR "Sleep period is too long, will poll queue once every 60 minutes\n";
+    $delay = 3600;
+}
+
+
+print "  Waiting for " . scalar( @jobIDs ) . " jobs: @jobIDs\n";
+
+my $errorsEncountered = 0;
+
+wait_for_all_jobs_to_complete(@jobIDs);
+
+if ($errorsEncountered) {
+    print "  No more jobs to run - some jobs had errors\n\n";
+    exit 1;
+}
+else {
+    print "  No more jobs in queue\n\n";
+    exit 0;
+}
+
+
+
+sub wait_for_all_jobs_to_complete {
+    my @pendingJobs = update_pending_jobs(@_);
+
+    while (@pendingJobs) {
+        if ($verbose) {
+            my $timestamp = `date`;
+            chomp $timestamp;
+            printf "  ($timestamp) Still waiting for %d jobs\n\n", scalar(@pendingJobs);
+        }
+
+        # Use of backticks rather than system permits a ctrl+c to work
+        `sleep $delay`;
+
+        @pendingJobs = update_pending_jobs(@pendingJobs);
+    };
+}
+
+sub update_pending_jobs {
+    my (@jobsToQuery) = @_;
+    my %jobStatuses = query_job_statuses(@jobsToQuery);
+
+    if (!scalar(@jobsToQuery) || !%jobStatuses)
+    {
+        # No more jobs remain
+        return ();
+    }
+
+    if ($verbose) {
+        while (my ($job, $status) = each(%jobStatuses)) {
+            print("    Job $job is in state $status\n");
+        }
+    }
+
+    my @terminatedJobs = grep {
+        !exists($jobStatuses{$jobsToQuery[$_]}) || exists($COMPLETION_STATES{$jobStatuses{$jobsToQuery[$_]}})
+    } 0..$#jobsToQuery;
+
+    my @failedJobs = grep {
+        exists($jobStatuses{$jobsToQuery[$_]}) && exists($FAILURE_STATES{$jobStatuses{$jobsToQuery[$_]}})
+    } 0..$#jobsToQuery;
+
+    if (@failedJobs) {
+        $errorsEncountered = 1;
+    }
+
+    push @terminatedJobs, @failedJobs;
+    foreach my $index (reverse(@terminatedJobs)) {
+        splice @jobsToQuery, $index, 1;
+    }
+
+    return @jobsToQuery;
+}
+
+sub query_job_statuses {
+    my (@jobsToQuery) = @_;
+    my $user = trim(`whoami`);
+    my $squeueOutput = qx/squeue --noheader --user="$user" --format="%i,%T" --jobs=${\join(',', @jobsToQuery)}/;
+    my $exitcode = $? >> 8;
+    my %jobStatuses = ();
+
+    if ($exitcode == 0) {
+        %jobStatuses = map {
+            my @statusParts = split(",", $_);
+            $statusParts[0] => $statusParts[1];
+        } split("\n", trim($squeueOutput));
+    }
+
+    return %jobStatuses;
+}
+
+sub trim {
+    my ($string) = @_;
+
+    $string =~ s/^\s+//;
+    $string =~ s/\s+$//;
+
+    return $string;
+}


### PR DESCRIPTION
I've added a `waitForSlurmJobs.pl` script modeled after the similar scripts for SGE, PBS, and XGrid.

I've also enhanced the 5 scripts that support cluster parallelization to also support SLURM:
* `antsJointLabelFusion.sh`
* `antsMalfLabeling.sh`
* `antsMultivariateTemplateConstruction.sh`
* `antsMultivariateTemplateConstruction2.sh`
* `buildtemplateparallel.sh`

Please note that I've only been able to test the `antJointLabelFusion.sh` and `antsMultivariateTemplateConstruction.sh` with real jobs.  I don't use the other scripts and thus don't have complete test cases I can use to verify expected behavior.


I'm happy to restructure my commits and submit separate pull requests for the well-tested and poorly-tested changes, and I'm also happy to go back and perform any stylistic (or other) modifications as appropriate.