### PR TITLE
COMP: Add missing ITK_OVERRIDE statements

### DIFF
--- a/Examples/DenoiseImage.cxx
+++ b/Examples/DenoiseImage.cxx
@@ -37,7 +37,7 @@ protected:
 
 public:
 
-  void Execute(itk::Object *caller, const itk::EventObject & event)
+  void Execute(itk::Object *caller, const itk::EventObject & event) ITK_OVERRIDE
     {
     itk::ProcessObject *po = dynamic_cast<itk::ProcessObject *>( caller );
     if (! po) return;
@@ -59,7 +59,7 @@ public:
       }
     }
 
-  void Execute(const itk::Object * object, const itk::EventObject & event)
+  void Execute(const itk::Object * object, const itk::EventObject & event) ITK_OVERRIDE
     {
     itk::ProcessObject *po = dynamic_cast<itk::ProcessObject *>(
       const_cast<itk::Object *>( object ) );

--- a/Examples/antsJointFusion.cxx
+++ b/Examples/antsJointFusion.cxx
@@ -37,7 +37,7 @@ protected:
 
 public:
 
-  void Execute(itk::Object *caller, const itk::EventObject & event)
+  void Execute(itk::Object *caller, const itk::EventObject & event) ITK_OVERRIDE
     {
     itk::ProcessObject *po = dynamic_cast<itk::ProcessObject *>( caller );
     if (! po) return;
@@ -59,7 +59,7 @@ public:
       }
     }
 
-  void Execute(const itk::Object * object, const itk::EventObject & event)
+  void Execute(const itk::Object * object, const itk::EventObject & event) ITK_OVERRIDE
     {
     itk::ProcessObject *po = dynamic_cast<itk::ProcessObject *>(
       const_cast<itk::Object *>( object ) );

--- a/Examples/antsJointTensorFusion.cxx
+++ b/Examples/antsJointTensorFusion.cxx
@@ -42,7 +42,7 @@ protected:
 
 public:
 
-  void Execute(itk::Object *caller, const itk::EventObject & event)
+  void Execute(itk::Object *caller, const itk::EventObject & event) ITK_OVERRIDE
     {
     itk::ProcessObject *po = dynamic_cast<itk::ProcessObject *>( caller );
     if (! po) return;
@@ -64,7 +64,7 @@ public:
       }
     }
 
-  void Execute(const itk::Object * object, const itk::EventObject & event)
+  void Execute(const itk::Object * object, const itk::EventObject & event) ITK_OVERRIDE
     {
     itk::ProcessObject *po = dynamic_cast<itk::ProcessObject *>(
       const_cast<itk::Object *>( object ) );

--- a/Temporary/itkMeanSquaresPointSetToPointSetIntensityMetricv4.h
+++ b/Temporary/itkMeanSquaresPointSetToPointSetIntensityMetricv4.h
@@ -138,7 +138,7 @@ public:
   /**
    * Prepare point sets for use.
    */
-  virtual void InitializePointSets() const;
+  virtual void InitializePointSets() const ITK_OVERRIDE;
 
   /**
    * Calculates the local metric value for a single point.

--- a/Utilities/itkImageIntensityAndGradientToPointSetFilter.h
+++ b/Utilities/itkImageIntensityAndGradientToPointSetFilter.h
@@ -102,7 +102,7 @@ public:
     return static_cast<const MaskImageType*>( this->ProcessObject::GetInput( 1 ) );
     }
 
-  void Update();
+  void Update() ITK_OVERRIDE;
 
   /**
    * Set/Get sigma for the gradient recursive gaussian image filter


### PR DESCRIPTION
When overriding a parent class function from ITK, we need
to use ITK_OVERRIDE to improve long term maintenance challenges
by ensuring that if the parent class API changes, these can be
readily found in the sub-classes.