### PR TITLE
rename 'sa' to 'adaBoostSegmentationRefinement'

### DIFF
--- a/ExternalApplications/MALF/CMakeLists.txt
+++ b/ExternalApplications/MALF/CMakeLists.txt
@@ -10,15 +10,15 @@ project(PICSL_MALF)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(jointfusion ./JointFusion/LabelFusion.cxx)
-add_executable(sa ./CorrectiveLearning/segAdapter.cxx)
+add_executable(adaBoostSegmentationRefinement ./CorrectiveLearning/segAdapter.cxx)
 add_executable(bl ./CorrectiveLearning/BiasLearn.cxx)
 
 target_link_libraries(jointfusion antsUtilities ${ITK_LIBRARIES} )
-target_link_libraries(sa ${ITK_LIBRARIES} )
+target_link_libraries(adaBoostSegmentationRefinement ${ITK_LIBRARIES} )
 target_link_libraries(bl ${ITK_LIBRARIES} )
 
 
-install(TARGETS jointfusion sa bl
+install(TARGETS jointfusion adaBoostSegmentationRefinement bl
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)

--- a/ExternalApplications/MALF/README.md
+++ b/ExternalApplications/MALF/README.md
@@ -40,9 +40,9 @@ make
 to complie and build the executable files. Our program uses ITK's I/O functions to handle image input
 and output. Hence, it requries prebuilt ITK. The following three executable files will be built,
 
-jointfusion : joint label fusion
-bl          : learning classifiers for correcting systematic errors
-sa          : apply the learned classifiers to correct systematic segmentation errors on testing images
+jointfusion                    : joint label fusion
+bl                             : learning classifiers for correcting systematic errors
+adaBoostSegmentationRefinement : apply the learned classifiers to correct systematic segmentation errors on testing images
 
 Type each command to see details on how to use them.
 


### PR DESCRIPTION
/usr/sbin/sa provided by psacct which is well-known utility and should be renamed.

Reference: https://github.com/stnava/ANTs/issues/242
Signed-off-by: Igor Gnatenko <i.gnatenko.brain@gmail.com>