### PR TITLE
ENH: Support correction of diffusion directions when motion correction is rigid

### DIFF
--- a/Examples/antsMotionCorrDiffusionDirection.cxx
+++ b/Examples/antsMotionCorrDiffusionDirection.cxx
@@ -313,6 +313,28 @@ int ants_motion_directions( itk::ants::CommandLineParser *parser )
   std::cout << "Read direction data of size: " << directionArray.rows() << " x "
               << directionArray.cols() << std::endl;
 
+  // itkImageFileReader will set direction to identity if the image being read has more dimensions than the template
+  //
+  // Therefore check reference image is 3D, and fail if not
+  //
+ itk::ImageIOBase::Pointer imageIO =
+   itk::ImageIOFactory::CreateImageIO(physicalName.c_str(), itk::ImageIOFactory::ReadMode);
+ imageIO->SetFileName(physicalName.c_str() );
+ try
+   {
+     imageIO->ReadImageInformation();
+   }
+ catch( ... )
+   {
+     std::cout << "Can't read reference image " << physicalName << std::endl;
+     return EXIT_FAILURE;
+   }
+ if (imageIO->GetNumberOfDimensions() != ImageDimension) 
+   {
+     std::cout << "Reference image must be 3D " << std::endl;
+     return EXIT_FAILURE;
+   }
+
   ImageReaderType::Pointer imageReader = ImageReaderType::New();
   imageReader->SetFileName(physicalName.c_str());
   imageReader->Update();
@@ -494,7 +516,7 @@ void antsMotionCorrDiffusionDirectionInitializeCommandLineOptions( itk::ants::Co
     }
 
     {
-    std::string description =       std::string( "image in dwi space");
+    std::string description =       std::string( "3D image in dwi space");
     OptionType::Pointer option = OptionType::New();
     option->SetLongName( "physical" );
     option->SetShortName( 'p' );

--- a/Examples/antsMotionCorrDiffusionDirection.cxx
+++ b/Examples/antsMotionCorrDiffusionDirection.cxx
@@ -313,7 +313,8 @@ int ants_motion_directions( itk::ants::CommandLineParser *parser )
   std::cout << "Read direction data of size: " << directionArray.rows() << " x "
               << directionArray.cols() << std::endl;
 
-  // itkImageFileReader will set direction to identity if the image being read has more dimensions than the template
+  // itkImageFileReader will set direction to identity if the image being read has more dimensions than the class template
+  // eg if you pass a 4D image file name to a ReaderType whose dimension is 3
   //
   // Therefore check reference image is 3D, and fail if not
   //


### PR DESCRIPTION
Previously this would only work with affine motion correction input.

Also require a 3D reference image for antsMotionCorrDiffusionDirection. This may be an inconvenience for some users but it is necessary to ensure that the direction matrix is set correctly.