### PR TITLE
ENH: allows ansCorticalThickness to be called via 5 separate stages

### DIFF
--- a/Scripts/antsCorticalThickness.sh
+++ b/Scripts/antsCorticalThickness.sh
@@ -677,7 +677,7 @@ CORTICAL_THICKNESS_IMAGE=${OUTPUT_PREFIX}CorticalThickness.${OUTPUT_SUFFIX}
 # Brain extraction
 #
 ################################################################################
-if [[ ! ${ACT_STAGE} -eq 0 || ${ACT_STAGE} -eq 1  ]] ; then # BAStages bxt
+if [ ${ACT_STAGE} -eq 0 ] || [ ${ACT_STAGE} -eq 1  ] ; then # BAStages bxt
 if [[ ! -f ${BRAIN_EXTRACTION_MASK} ]];
   then
 
@@ -750,7 +750,7 @@ SEGMENTATION_GENERIC_AFFINE=${SEGMENTATION_WARP_OUTPUT_PREFIX}0GenericAffine.mat
 SEGMENTATION_MASK_DILATED=${BRAIN_SEGMENTATION_OUTPUT}MaskDilated.nii.gz
 SEGMENTATION_CONVERGENCE_FILE=${BRAIN_SEGMENTATION_OUTPUT}Convergence.txt
 
-if [[ ! ${ACT_STAGE} -eq 0 || ${ACT_STAGE} -eq 2  ]] ; then # BAStages seg
+if [ ${ACT_STAGE} -eq 0 ] || [ ${ACT_STAGE} -eq 2  ] ; then # BAStages seg
 if [[ ! -f ${BRAIN_SEGMENTATION} ]];
   then
 
@@ -999,7 +999,7 @@ REGISTRATION_SUBJECT_WARP=${REGISTRATION_SUBJECT_OUTPUT_PREFIX}0Warp.${OUTPUT_SU
 HEAD_N4_IMAGE=${OUTPUT_PREFIX}BrainSegmentation0N4.${OUTPUT_SUFFIX}
 EXTRACTED_SEGMENTATION_BRAIN_N4_IMAGE=${OUTPUT_PREFIX}ExtractedBrain0N4.nii.gz
 
-if [[ ! ${ACT_STAGE} -eq 0 || ${ACT_STAGE} -eq 3  ]] ; then # BAStages temreg
+if [ ${ACT_STAGE} -eq 0 ] || [ ${ACT_STAGE} -eq 3  ] ; then # BAStages temreg
 
 if [[ -f ${REGISTRATION_TEMPLATE} ]] && [[ ! -f $REGISTRATION_LOG_JACOBIAN ]];
   then
@@ -1111,7 +1111,7 @@ CORTICAL_THICKNESS_SEGMENTATION=${OUTPUT_PREFIX}CorticalThicknessSegmentation.${
 CORTICAL_THICKNESS_GM_SEGMENTATION=${OUTPUT_PREFIX}CorticalThicknessGMSegmentation.${OUTPUT_SUFFIX}
 CORTICAL_LABEL_THICKNESS_PRIOR=${OUTPUT_PREFIX}CorticalLabelThicknessPrior.${OUTPUT_SUFFIX}
 
-if [[ ! ${ACT_STAGE} -eq 0 || ${ACT_STAGE} -eq 4  ]] ; then # BAStages direct
+if [ ${ACT_STAGE} -eq 0 ] || [ ${ACT_STAGE} -eq 4  ] ; then # BAStages direct
 if [[ ! -f ${CORTICAL_THICKNESS_IMAGE} ]];
   then
 
@@ -1238,7 +1238,7 @@ if [[ ! -f ${CORTICAL_THICKNESS_IMAGE} ]];
 fi # BAStages
 
 #### BA Edits Begin ####
-if [[ ! ${ACT_STAGE} -eq 0 || ${ACT_STAGE} -eq 5  ]] ; then # BAStages qc
+if [ ${ACT_STAGE} -eq 0 ] || [ ${ACT_STAGE} -eq 5  ] ; then # BAStages qc
 echo "--------------------------------------------------------------------------------------"
 echo "Compute summary measurements"
 echo "--------------------------------------------------------------------------------------"

--- a/Scripts/antsCorticalThickness.sh
+++ b/Scripts/antsCorticalThickness.sh
@@ -737,6 +737,7 @@ if [[ -f ${BRAIN_TEMPLATE} ]] && [[ ! -f ${EXTRACTED_BRAIN_TEMPLATE} ]];
     logCmd ${ANTSPATH}/ThresholdImage ${DIMENSION} ${EXTRACTION_PRIOR} ${EXTRACTED_BRAIN_TEMPLATE} 0.1 1.01 1 0
     logCmd ${ANTSPATH}/ImageMath ${DIMENSION} ${EXTRACTED_BRAIN_TEMPLATE} m ${BRAIN_TEMPLATE} ${EXTRACTED_BRAIN_TEMPLATE}
   fi
+echo ${OUTPUT_PREFIX}ACTStage1Complete.txt > ${OUTPUT_PREFIX}ACTStage1Complete.txt
 fi # BAStages
 
 ################################################################################
@@ -975,6 +976,7 @@ if [[ ! -f ${BRAIN_SEGMENTATION} ]];
     echo
 
    fi
+   echo ${OUTPUT_PREFIX}ACTStage2Complete.txt > ${OUTPUT_PREFIX}ACTStage2Complete.txt
 fi # BAStages ending here seems safe because no variable definitions above
 
 ################################################################################
@@ -1091,6 +1093,7 @@ if [[ -f ${REGISTRATION_TEMPLATE} ]] && [[ ! -f $REGISTRATION_LOG_JACOBIAN ]];
         done
       fi
   fi # if registration template & jacobian check
+  echo ${OUTPUT_PREFIX}ACTStage3Complete.txt > ${OUTPUT_PREFIX}ACTStage3Complete.txt
 fi # BAStages
 
 
@@ -1235,6 +1238,7 @@ if [[ ! -f ${CORTICAL_THICKNESS_IMAGE} ]];
     echo
 
   fi
+  echo ${OUTPUT_PREFIX}ACTStage4Complete.txt > ${OUTPUT_PREFIX}ACTStage4Complete.txt
 fi # BAStages
 
 #### BA Edits Begin ####
@@ -1376,7 +1380,8 @@ if [[ ! -f ${CORTICAL_THICKNESS_MOSAIC} || ! -f ${BRAIN_SEGMENTATION_MOSAIC} ]];
         done
       fi
   fi
-fi # BASTAGES
+  echo ${OUTPUT_PREFIX}ACTStage5Complete.txt > ${OUTPUT_PREFIX}ACTStage5Complete.txt
+fi # BAStages
 ################################################################################
 #
 # End of main routine

--- a/Scripts/antsCorticalThickness.sh
+++ b/Scripts/antsCorticalThickness.sh
@@ -680,7 +680,7 @@ CORTICAL_THICKNESS_IMAGE=${OUTPUT_PREFIX}CorticalThickness.${OUTPUT_SUFFIX}
 EXTRACTED_SEGMENTATION_BRAIN=${OUTPUT_PREFIX}BrainExtractionBrain.${OUTPUT_SUFFIX}
 EXTRACTION_GENERIC_AFFINE=${OUTPUT_PREFIX}BrainExtractionPrior0GenericAffine.mat
 EXTRACTED_BRAIN_TEMPLATE=${OUTPUT_PREFIX}ExtractedTemplateBrain.${OUTPUT_SUFFIX}
-if [ ${ACT_STAGE} -eq 0 ] || [ ${ACT_STAGE} -eq 1  ] ; then # BAStages bxt
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 1  ] || [[ ! -s ${OUTPUT_PREFIX}ACTStage1Complete.txt ]]; then # BAStages bxt
 if [[ ! -f ${BRAIN_EXTRACTION_MASK} ]];
   then
 
@@ -751,7 +751,7 @@ SEGMENTATION_GENERIC_AFFINE=${SEGMENTATION_WARP_OUTPUT_PREFIX}0GenericAffine.mat
 SEGMENTATION_MASK_DILATED=${BRAIN_SEGMENTATION_OUTPUT}MaskDilated.nii.gz
 SEGMENTATION_CONVERGENCE_FILE=${BRAIN_SEGMENTATION_OUTPUT}Convergence.txt
 
-if [ ${ACT_STAGE} -eq 0 ] || [ ${ACT_STAGE} -eq 2  ] ; then # BAStages seg
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 2  ] || [[ ! -s ${OUTPUT_PREFIX}ACTStage2Complete.txt ]]; then # BAStages seg
 if [[ ! -f ${BRAIN_SEGMENTATION} ]];
   then
 
@@ -1001,7 +1001,7 @@ REGISTRATION_SUBJECT_WARP=${REGISTRATION_SUBJECT_OUTPUT_PREFIX}0Warp.${OUTPUT_SU
 HEAD_N4_IMAGE=${OUTPUT_PREFIX}BrainSegmentation0N4.${OUTPUT_SUFFIX}
 EXTRACTED_SEGMENTATION_BRAIN_N4_IMAGE=${OUTPUT_PREFIX}ExtractedBrain0N4.nii.gz
 
-if [ ${ACT_STAGE} -eq 0 ] || [ ${ACT_STAGE} -eq 3  ] ; then # BAStages temreg
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 3  ] || [[ ! -s ${OUTPUT_PREFIX}ACTStage3Complete.txt ]]; then # BAStages reg
 
 if [[ -f ${REGISTRATION_TEMPLATE} ]] && [[ ! -f $REGISTRATION_LOG_JACOBIAN ]];
   then
@@ -1114,7 +1114,7 @@ CORTICAL_THICKNESS_SEGMENTATION=${OUTPUT_PREFIX}CorticalThicknessSegmentation.${
 CORTICAL_THICKNESS_GM_SEGMENTATION=${OUTPUT_PREFIX}CorticalThicknessGMSegmentation.${OUTPUT_SUFFIX}
 CORTICAL_LABEL_THICKNESS_PRIOR=${OUTPUT_PREFIX}CorticalLabelThicknessPrior.${OUTPUT_SUFFIX}
 
-if [ ${ACT_STAGE} -eq 0 ] || [ ${ACT_STAGE} -eq 4  ] ; then # BAStages direct
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 4  ] || [[ ! -s ${OUTPUT_PREFIX}ACTStage4Complete.txt ]]; then # BAStages thk
 if [[ ! -f ${CORTICAL_THICKNESS_IMAGE} ]];
   then
 
@@ -1242,7 +1242,7 @@ if [[ ! -f ${CORTICAL_THICKNESS_IMAGE} ]];
 fi # BAStages
 
 #### BA Edits Begin ####
-if [ ${ACT_STAGE} -eq 0 ] || [ ${ACT_STAGE} -eq 5  ] ; then # BAStages qc
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 5  ] || [[ ! -s ${OUTPUT_PREFIX}ACTStage5Complete.txt ]]; then # BAStages qc
 echo "--------------------------------------------------------------------------------------"
 echo "Compute summary measurements"
 echo "--------------------------------------------------------------------------------------"

--- a/Scripts/antsCorticalThickness.sh
+++ b/Scripts/antsCorticalThickness.sh
@@ -677,6 +677,9 @@ CORTICAL_THICKNESS_IMAGE=${OUTPUT_PREFIX}CorticalThickness.${OUTPUT_SUFFIX}
 # Brain extraction
 #
 ################################################################################
+EXTRACTED_SEGMENTATION_BRAIN=${OUTPUT_PREFIX}BrainExtractionBrain.${OUTPUT_SUFFIX}
+EXTRACTION_GENERIC_AFFINE=${OUTPUT_PREFIX}BrainExtractionPrior0GenericAffine.mat
+EXTRACTED_BRAIN_TEMPLATE=${OUTPUT_PREFIX}ExtractedTemplateBrain.${OUTPUT_SUFFIX}
 if [ ${ACT_STAGE} -eq 0 ] || [ ${ACT_STAGE} -eq 1  ] ; then # BAStages bxt
 if [[ ! -f ${BRAIN_EXTRACTION_MASK} ]];
   then
@@ -723,21 +726,18 @@ if [[ ! -f ${BRAIN_EXTRACTION_MASK} ]];
       fi
 
   fi
-fi # BAStages end here because of variable definitions below
 
-EXTRACTED_SEGMENTATION_BRAIN=${OUTPUT_PREFIX}BrainExtractionBrain.${OUTPUT_SUFFIX}
 if [[ ! -f ${EXTRACTED_SEGMENTATION_BRAIN} ]];
   then
     logCmd ${ANTSPATH}/ImageMath ${DIMENSION} ${EXTRACTED_SEGMENTATION_BRAIN} m ${ANATOMICAL_IMAGES[0]} ${BRAIN_EXTRACTION_MASK}
   fi
 
-EXTRACTION_GENERIC_AFFINE=${OUTPUT_PREFIX}BrainExtractionPrior0GenericAffine.mat
-EXTRACTED_BRAIN_TEMPLATE=${OUTPUT_PREFIX}ExtractedTemplateBrain.${OUTPUT_SUFFIX}
 if [[ -f ${BRAIN_TEMPLATE} ]] && [[ ! -f ${EXTRACTED_BRAIN_TEMPLATE} ]];
   then
     logCmd ${ANTSPATH}/ThresholdImage ${DIMENSION} ${EXTRACTION_PRIOR} ${EXTRACTED_BRAIN_TEMPLATE} 0.1 1.01 1 0
     logCmd ${ANTSPATH}/ImageMath ${DIMENSION} ${EXTRACTED_BRAIN_TEMPLATE} m ${BRAIN_TEMPLATE} ${EXTRACTED_BRAIN_TEMPLATE}
   fi
+fi # BAStages
 
 ################################################################################
 #

--- a/Scripts/antsCorticalThickness.sh
+++ b/Scripts/antsCorticalThickness.sh
@@ -680,7 +680,8 @@ CORTICAL_THICKNESS_IMAGE=${OUTPUT_PREFIX}CorticalThickness.${OUTPUT_SUFFIX}
 EXTRACTED_SEGMENTATION_BRAIN=${OUTPUT_PREFIX}BrainExtractionBrain.${OUTPUT_SUFFIX}
 EXTRACTION_GENERIC_AFFINE=${OUTPUT_PREFIX}BrainExtractionPrior0GenericAffine.mat
 EXTRACTED_BRAIN_TEMPLATE=${OUTPUT_PREFIX}ExtractedTemplateBrain.${OUTPUT_SUFFIX}
-if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 1  ] || [[ ! -s ${OUTPUT_PREFIX}ACTStage1Complete.txt ]]; then # BAStages bxt
+if [[ ! -s ${OUTPUT_PREFIX}ACTStage1Complete.txt ]]; then
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 1  ]] || [[ ! -s ${OUTPUT_PREFIX}ACTStage1Complete.txt ]]; then # BAStages bxt
 if [[ ! -f ${BRAIN_EXTRACTION_MASK} ]];
   then
 
@@ -739,6 +740,7 @@ if [[ -f ${BRAIN_TEMPLATE} ]] && [[ ! -f ${EXTRACTED_BRAIN_TEMPLATE} ]];
   fi
 echo ${OUTPUT_PREFIX}ACTStage1Complete.txt > ${OUTPUT_PREFIX}ACTStage1Complete.txt
 fi # BAStages
+fi # check completion
 
 ################################################################################
 #
@@ -751,7 +753,8 @@ SEGMENTATION_GENERIC_AFFINE=${SEGMENTATION_WARP_OUTPUT_PREFIX}0GenericAffine.mat
 SEGMENTATION_MASK_DILATED=${BRAIN_SEGMENTATION_OUTPUT}MaskDilated.nii.gz
 SEGMENTATION_CONVERGENCE_FILE=${BRAIN_SEGMENTATION_OUTPUT}Convergence.txt
 
-if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 2  ] || [[ ! -s ${OUTPUT_PREFIX}ACTStage2Complete.txt ]]; then # BAStages seg
+if [[ ! -s ${OUTPUT_PREFIX}ACTStage2Complete.txt ]]; then
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 2  ]] ; then # BAStages seg
 if [[ ! -f ${BRAIN_SEGMENTATION} ]];
   then
 
@@ -978,6 +981,7 @@ if [[ ! -f ${BRAIN_SEGMENTATION} ]];
    fi
    echo ${OUTPUT_PREFIX}ACTStage2Complete.txt > ${OUTPUT_PREFIX}ACTStage2Complete.txt
 fi # BAStages ending here seems safe because no variable definitions above
+fi # check completion
 
 ################################################################################
 #
@@ -1001,7 +1005,8 @@ REGISTRATION_SUBJECT_WARP=${REGISTRATION_SUBJECT_OUTPUT_PREFIX}0Warp.${OUTPUT_SU
 HEAD_N4_IMAGE=${OUTPUT_PREFIX}BrainSegmentation0N4.${OUTPUT_SUFFIX}
 EXTRACTED_SEGMENTATION_BRAIN_N4_IMAGE=${OUTPUT_PREFIX}ExtractedBrain0N4.nii.gz
 
-if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 3  ] || [[ ! -s ${OUTPUT_PREFIX}ACTStage3Complete.txt ]]; then # BAStages reg
+if [[ ! -s ${OUTPUT_PREFIX}ACTStage3Complete.txt ]]; then
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 3  ]] ; then # BAStages reg
 
 if [[ -f ${REGISTRATION_TEMPLATE} ]] && [[ ! -f $REGISTRATION_LOG_JACOBIAN ]];
   then
@@ -1095,6 +1100,7 @@ if [[ -f ${REGISTRATION_TEMPLATE} ]] && [[ ! -f $REGISTRATION_LOG_JACOBIAN ]];
   fi # if registration template & jacobian check
   echo ${OUTPUT_PREFIX}ACTStage3Complete.txt > ${OUTPUT_PREFIX}ACTStage3Complete.txt
 fi # BAStages
+fi # check completion
 
 
 
@@ -1114,7 +1120,8 @@ CORTICAL_THICKNESS_SEGMENTATION=${OUTPUT_PREFIX}CorticalThicknessSegmentation.${
 CORTICAL_THICKNESS_GM_SEGMENTATION=${OUTPUT_PREFIX}CorticalThicknessGMSegmentation.${OUTPUT_SUFFIX}
 CORTICAL_LABEL_THICKNESS_PRIOR=${OUTPUT_PREFIX}CorticalLabelThicknessPrior.${OUTPUT_SUFFIX}
 
-if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 4  ] || [[ ! -s ${OUTPUT_PREFIX}ACTStage4Complete.txt ]]; then # BAStages thk
+if [[ ! -s ${OUTPUT_PREFIX}ACTStage4Complete.txt ]]; then
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 4  ]] ; then # BAStages thk
 if [[ ! -f ${CORTICAL_THICKNESS_IMAGE} ]];
   then
 
@@ -1240,9 +1247,11 @@ if [[ ! -f ${CORTICAL_THICKNESS_IMAGE} ]];
   fi
   echo ${OUTPUT_PREFIX}ACTStage4Complete.txt > ${OUTPUT_PREFIX}ACTStage4Complete.txt
 fi # BAStages
+fi # check completion
 
 #### BA Edits Begin ####
-if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 5  ] || [[ ! -s ${OUTPUT_PREFIX}ACTStage5Complete.txt ]]; then # BAStages qc
+if [[ ! -s ${OUTPUT_PREFIX}ACTStage5Complete.txt ]]; then
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 5  ]] ; then # BAStages qc
 echo "--------------------------------------------------------------------------------------"
 echo "Compute summary measurements"
 echo "--------------------------------------------------------------------------------------"
@@ -1382,6 +1391,7 @@ if [[ ! -f ${CORTICAL_THICKNESS_MOSAIC} || ! -f ${BRAIN_SEGMENTATION_MOSAIC} ]];
   fi
   echo ${OUTPUT_PREFIX}ACTStage5Complete.txt > ${OUTPUT_PREFIX}ACTStage5Complete.txt
 fi # BAStages
+fi # check completion
 ################################################################################
 #
 # End of main routine

--- a/Scripts/antsCorticalThickness.sh
+++ b/Scripts/antsCorticalThickness.sh
@@ -142,6 +142,7 @@ Optional arguments:
                                                 to a template.  Otherwise use antsRegistrationSyN.sh (default = 0).
      -x:                                        Number of iterations within Atropos (default 5).
      -y:                                        Which stage of ACT to run (default = 0, run all).  Tries to split in 2 hour chunks.
+                                                Will produce OutputNameACTStageNComplete.txt for each completed stage.
                                                 1: brain extraction
                                                 2: tissue segmentation
                                                 3: template registration

--- a/Scripts/antsCorticalThickness.sh
+++ b/Scripts/antsCorticalThickness.sh
@@ -681,7 +681,7 @@ EXTRACTED_SEGMENTATION_BRAIN=${OUTPUT_PREFIX}BrainExtractionBrain.${OUTPUT_SUFFI
 EXTRACTION_GENERIC_AFFINE=${OUTPUT_PREFIX}BrainExtractionPrior0GenericAffine.mat
 EXTRACTED_BRAIN_TEMPLATE=${OUTPUT_PREFIX}ExtractedTemplateBrain.${OUTPUT_SUFFIX}
 if [[ ! -s ${OUTPUT_PREFIX}ACTStage1Complete.txt ]]; then
-if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 1  ]] || [[ ! -s ${OUTPUT_PREFIX}ACTStage1Complete.txt ]]; then # BAStages bxt
+if [[ ${ACT_STAGE} -eq 0 ]] || [[ ${ACT_STAGE} -eq 1  ]] ; then # BAStages bxt
 if [[ ! -f ${BRAIN_EXTRACTION_MASK} ]];
   then
 


### PR DESCRIPTION
allow stages 1 to 5 to be called separately and in order.  this permits finer grained control over the process timing. produces nearly identical results to and is backward compatible with the unstaged antsCorticalThickness.  the test comparison is based on the ants example for antsCorticalThickness:
    
    #!/bin/bash
    DATA_DIR=${PWD}
    TEMPLATE_DIR=${DATA_DIR}/Template/
    OUT_DIR=${DATA_DIR}/OutputT1Only/
    
    bash ${ANTSPATH}antsCorticalThickness.sh -d 2 -x 25 -u 0 \
      -a ${DATA_DIR}/IXI002-Guys-0828-T1_slice90.nii.gz \
      -e ${TEMPLATE_DIR}template_slice80.nii.gz \
      -m ${TEMPLATE_DIR}template_cerebrum_mask_slice80.nii.gz \
      -p ${TEMPLATE_DIR}prior%d_slice80.nii.gz \
      -o ${OUT_DIR}example
    
    # test stages
    OUT_DIR=${DATA_DIR}/OutputT1OnlyByStage/
    for stage in 1 2 3 4 5 ; do
      bash ${ANTSPATH}antsCorticalThickness.sh -d 2 -x 25 -u 0 -y $stage \
        -a ${DATA_DIR}/IXI002-Guys-0828-T1_slice90.nii.gz \
        -e ${TEMPLATE_DIR}template_slice80.nii.gz \
        -m ${TEMPLATE_DIR}template_cerebrum_mask_slice80.nii.gz \
        -p ${TEMPLATE_DIR}prior%d_slice80.nii.gz \
        -o ${OUT_DIR}example
    done
    
which produces (nearly) identical output.  following stages require previous stages to be called.