### PR TITLE
Normalize denoised image to input range

### DIFF
--- a/Examples/DenoiseImage.cxx
+++ b/Examples/DenoiseImage.cxx
@@ -128,6 +128,8 @@ int Denoise( itk::ants::CommandLineParser *parser )
 
   typedef itk::AdaptiveNonLocalMeansDenoisingImageFilter<ImageType, ImageType> DenoiserType;
   typename DenoiserType::Pointer denoiser = DenoiserType::New();
+  //Perhaps make this a command line option?
+  denoiser->SetRescaleToInputDynamicRange( true );
 
   typedef itk::ShrinkImageFilter<ImageType, ImageType> ShrinkerType;
   typename ShrinkerType::Pointer shrinker = ShrinkerType::New();

--- a/Examples/DenoiseImage.cxx
+++ b/Examples/DenoiseImage.cxx
@@ -88,12 +88,6 @@ int Denoise( itk::ants::CommandLineParser *parser )
 {
   typedef float RealType;
 
-  typedef itk::Image<RealType, ImageDimension> ImageType;
-  typename ImageType::Pointer inputImage = ITK_NULLPTR;
-
-  typedef itk::Image<RealType, ImageDimension> MaskImageType;
-  typename MaskImageType::Pointer maskImage = ITK_NULLPTR;
-
   bool verbose = false;
   typename itk::ants::CommandLineParser::OptionType::Pointer verboseOption =
     parser->GetOption( "verbose" );
@@ -107,6 +101,12 @@ int Denoise( itk::ants::CommandLineParser *parser )
     std::cout << std::endl << "Running for "
              << ImageDimension << "-dimensional images." << std::endl << std::endl;
     }
+
+  typedef itk::Image<RealType, ImageDimension> ImageType;
+  typename ImageType::Pointer inputImage = ITK_NULLPTR;
+
+  //typedef itk::Image<RealType, ImageDimension> MaskImageType;
+  //typename MaskImageType::Pointer maskImage = ITK_NULLPTR;
 
   typename itk::ants::CommandLineParser::OptionType::Pointer inputImageOption =
     parser->GetOption( "input-image" );
@@ -253,18 +253,20 @@ int Denoise( itk::ants::CommandLineParser *parser )
     subtracter->SetInput1( denoiser->GetInput() );
     subtracter->SetInput2( denoiser->GetOutput() );
 
-    typedef itk::IdentityTransform<RealType, ImageDimension> TransformType;
-    typename TransformType::Pointer transform = TransformType::New();
-    transform->SetIdentity();
-
-    typedef itk::LinearInterpolateImageFunction<ImageType, RealType> LinearInterpolatorType;
-    typename LinearInterpolatorType::Pointer interpolator = LinearInterpolatorType::New();
-    interpolator->SetInputImage( subtracter->GetOutput() );
-
     typedef itk::ResampleImageFilter<ImageType, ImageType, RealType> ResamplerType;
     typename ResamplerType::Pointer resampler = ResamplerType::New();
-    resampler->SetTransform( transform );
-    resampler->SetInterpolator( interpolator );
+    {
+      typedef itk::IdentityTransform<RealType, ImageDimension> TransformType;
+      typename TransformType::Pointer transform = TransformType::New();
+      transform->SetIdentity();
+      resampler->SetTransform( transform );
+    }
+    {
+      typedef itk::LinearInterpolateImageFunction<ImageType, RealType> LinearInterpolatorType;
+      typename LinearInterpolatorType::Pointer interpolator = LinearInterpolatorType::New();
+      interpolator->SetInputImage( subtracter->GetOutput() );
+      resampler->SetInterpolator( interpolator );
+    }
     resampler->SetOutputParametersFromImage( inputImage );
     resampler->UseReferenceImageOn();
     resampler->SetInput( subtracter->GetOutput() );

--- a/Utilities/ReadWriteData.h
+++ b/Utilities/ReadWriteData.h
@@ -289,8 +289,8 @@ typename ImageType::Pointer ReadImage(char* fn )
     return NULL;
     }
 
-  typename ImageType::DirectionType dir;
-  dir.SetIdentity();
+  //typename ImageType::DirectionType dir;
+  //dir.SetIdentity();
   //  reffilter->GetOutput()->SetDirection(dir);
 
   typename ImageType::Pointer target = reffilter->GetOutput();
@@ -488,7 +488,7 @@ bool WritePointSet( itk::SmartPointer<TPointSet> pointSet, const char *file )
 }
 
 template <class TImageType>
-bool WriteImage(itk::SmartPointer<TImageType> image, const char *file)
+bool WriteImage(const itk::SmartPointer<TImageType> image, const char *file)
 {
   if( std::string(file).length() < 3 )
     {

--- a/Utilities/itkAdaptiveNonLocalMeansDenoisingImageFilter.h
+++ b/Utilities/itkAdaptiveNonLocalMeansDenoisingImageFilter.h
@@ -163,10 +163,8 @@ protected:
 
 private:
 
-  AdaptiveNonLocalMeansDenoisingImageFilter( const Self& ); //purposely not
-                                                             // implemented
-  void operator=( const Self& );                      //purposely not
-                                                      // implemented
+  AdaptiveNonLocalMeansDenoisingImageFilter( const Self& ) ITK_DELETE_FUNCTION;
+  void operator=( const Self& ) ITK_DELETE_FUNCTION;
 
   RealType CalculateCorrectionFactor( RealType );
 

--- a/Utilities/itkAdaptiveNonLocalMeansDenoisingImageFilter.h
+++ b/Utilities/itkAdaptiveNonLocalMeansDenoisingImageFilter.h
@@ -88,6 +88,14 @@ public:
   void SetInput1( const InputImageType *image ) { this->SetInput( image ); }
 
   /**
+   * Rescale the output image to have a dynamic range similar to the input image.
+   * Default = true.
+   */
+  itkSetMacro( RescaleToInputDynamicRange, bool );
+  itkGetConstMacro( RescaleToInputDynamicRange, bool );
+  itkBooleanMacro( RescaleToInputDynamicRange );
+
+  /**
    * Employ Rician noise model.  Otherwise use a Gaussian noise model.
    * Default = true.
    */
@@ -168,6 +176,7 @@ private:
 
   RealType CalculateCorrectionFactor( RealType );
 
+  bool                              m_RescaleToInputDynamicRange;
   bool                              m_UseRicianNoiseModel;
 
   ModifiedBesselCalculatorType      m_ModifiedBesselCalculator;

--- a/Utilities/itkAdaptiveNonLocalMeansDenoisingImageFilter.hxx
+++ b/Utilities/itkAdaptiveNonLocalMeansDenoisingImageFilter.hxx
@@ -112,7 +112,7 @@ AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage>
 
   this->m_NeighborhoodOffsetList.clear();
 
-  unsigned int neighborhoodBlockSize = ( ItBI.GetNeighborhood() ).Size();
+  const unsigned int neighborhoodBlockSize = ( ItBI.GetNeighborhood() ).Size();
   for( unsigned int n = 0; n < neighborhoodBlockSize; n++ )
     {
     this->m_NeighborhoodOffsetList.push_back( ( ItBI.GetNeighborhood() ).GetOffset( n ) );
@@ -141,8 +141,8 @@ AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage>
   NeighborhoodIterator<InputImageType> ItBO( this->m_BlockNeighborhoodRadius, outputImage, region );
   NeighborhoodIterator<RealImageType> ItBL( this->m_BlockNeighborhoodRadius, this->m_ThreadContributionCountImage, region );
 
-  unsigned int neighborhoodSize = ( ItM.GetNeighborhood() ).Size();
-  unsigned int neighborhoodBlockSize = ( ItBM.GetNeighborhood() ).Size();
+  const unsigned int neighborhoodSize = ( ItM.GetNeighborhood() ).Size();
+  const unsigned int neighborhoodBlockSize = ( ItBM.GetNeighborhood() ).Size();
 
   Array<RealType> weightedAverageIntensities( neighborhoodBlockSize );
 
@@ -186,11 +186,11 @@ AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage>
           continue;
           }
 
-        RealType meanRatio = meanCenterPixel / meanNeighborhoodPixel;
-        RealType meanRatioInverse = ( this->m_MaximumInputPixelIntensity - meanCenterPixel ) /
+        const RealType meanRatio = meanCenterPixel / meanNeighborhoodPixel;
+        const RealType meanRatioInverse = ( this->m_MaximumInputPixelIntensity - meanCenterPixel ) /
           ( this->m_MaximumInputPixelIntensity - meanNeighborhoodPixel );
 
-        RealType varianceRatio = varianceCenterPixel / varianceNeighborhoodPixel;
+        const RealType varianceRatio = varianceCenterPixel / varianceNeighborhoodPixel;
 
         if( ( ( meanRatio > this->m_MeanThreshold && meanRatio < 1.0 / this->m_MeanThreshold ) ||
             ( meanRatioInverse > this->m_MeanThreshold && meanRatioInverse < 1.0 / this->m_MeanThreshold ) ) &&
@@ -259,11 +259,11 @@ AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage>
           continue;
           }
 
-        RealType meanRatio = meanCenterPixel / meanNeighborhoodPixel;
-        RealType meanRatioInverse = ( this->m_MaximumInputPixelIntensity - meanCenterPixel ) /
+        const RealType meanRatio = meanCenterPixel / meanNeighborhoodPixel;
+        const RealType meanRatioInverse = ( this->m_MaximumInputPixelIntensity - meanCenterPixel ) /
           ( this->m_MaximumInputPixelIntensity - meanNeighborhoodPixel );
 
-        RealType varianceRatio = varianceCenterPixel / varianceNeighborhoodPixel;
+        const RealType varianceRatio = varianceCenterPixel / varianceNeighborhoodPixel;
 
         if( ( ( meanRatio > this->m_MeanThreshold && meanRatio < 1.0 / this->m_MeanThreshold ) ||
             ( meanRatioInverse > this->m_MeanThreshold && meanRatioInverse < 1.0 / this->m_MeanThreshold ) ) &&
@@ -418,7 +418,7 @@ AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage>
 
     for( ItB.GoToBegin(), ItS.GoToBegin(), ItM.GoToBegin(); !ItS.IsAtEnd(); ++ItS, ++ItB, ++ItM )
       {
-      RealType snr = ItM.Get() / std::sqrt( ItS.Get() );
+      const RealType snr = ItM.Get() / std::sqrt( ItS.Get() );
 
       RealType bias = 2.0 * ItS.Get() / this->CalculateCorrectionFactor( snr );
 
@@ -467,7 +467,7 @@ typename AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage>::R
 AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage>
 ::CalculateCorrectionFactor( RealType snr )
 {
-   RealType snrSquared = vnl_math_sqr( snr );
+   const RealType snrSquared = vnl_math_sqr( snr );
 
    RealType value = 2.0 + snrSquared - 0.125 * vnl_math::pi * std::exp( -0.5 * snrSquared ) *
      vnl_math_sqr( ( 2.0 + snrSquared ) * this->m_ModifiedBesselCalculator.ModifiedBesselI0( 0.25 * snrSquared ) +


### PR DESCRIPTION
@ntustison Nick,  The denoising program is very nice, but the output images where on a vastly different range than the input images.  This was pretty easy to remedy by simply applying a linear intensity transfer function such that the intensity rescaled output is most like the input image.

This patch hardcodes to always do the rescaling (a computationally cheap operation).  It should be easy to add a command line option for turning this on/off, but I'm not fluent in the ants command line option behaviors. 