### PR TITLE
antsMultivariateTemplateConstruction2 not prefixing SGE jobs correctly

### DIFF
--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -1313,14 +1313,12 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
                 indir=`pwd`
               fi
             IMGbase=`basename ${IMAGESETARRAY[$l]}`
-            POO=${OUTPUTNAME}template${k}${IMGbase}
-            OUTFN=${POO%.*.*}
+            OUTFN=${OUTPUTNAME}template${k}${IMGbase%%.*}
             OUTFN=`basename ${OUTFN}`
             DEFORMED="${outdir}/${OUTFN}${l}WarpedToTemplate.nii.gz"
 
             IMGbase=`basename ${IMAGESETARRAY[$j]}`
-            POO=${OUTPUTNAME}${IMGbase}
-            OUTWARPFN=${POO%.*.*}
+            OUTWARPFN=${OUTPUTNAME}${IMGbase%%.*}
             OUTWARPFN=`basename ${OUTWARPFN}`
             OUTWARPFN="${OUTWARPFN}${j}"
 
@@ -1353,8 +1351,7 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
         done
 
         IMGbase=`basename ${IMAGESETARRAY[$j]}`
-        POO=${OUTPUTNAME}${IMGbase}
-        OUTWARPFN=${POO%.*.*}
+        OUTWARPFN=${OUTPUTNAME}${IMGbase%%.*}
         OUTWARPFN=`basename ${OUTWARPFN}${j}`
 
         stage0="-r [${TEMPLATES[0]},${IMAGESETARRAY[$j]},1]"

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -1391,7 +1391,8 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
         # 6 submit to SGE (DOQSUB=1), PBS (DOQSUB=4), PEXEC (DOQSUB=2), XGrid (DOQSUB=3), SLURM (DOQSUB=5) or else run locally (DOQSUB=0)
         if [[ $DOQSUB -eq 1 ]];
           then
-            echo -e "$exe" > $qscript
+			echo "$SCRIPTPREPEND" > $qscript
+            echo -e "$exe" >> $qscript
             id=`qsub -cwd -N antsBuildTemplate_deformable_${i} -S /bin/bash -v ANTSPATH=$ANTSPATH $QSUBOPTS $qscript | awk '{print $3}'`
             jobIDs="$jobIDs $id"
             sleep 0.5


### PR DESCRIPTION
Hello,
I think I found and fixed a small bug where the job prefix was not being written out for SGE jobs in the 2nd stage.
I also took the opportunity to change the pattern used to strip file extensions from %.*.* to %%.* - the latter will match against .nii as well as .nii.gz, if anyone wants to change the script to output uncompressed Nifti files.
Thanks,
TOby