### PR TITLE
ENH: Masking operations uniform use nonzero values

### DIFF
--- a/Examples/Atropos.cxx
+++ b/Examples/Atropos.cxx
@@ -416,7 +416,7 @@ int AtroposSegmentation( itk::ants::CommandLineParser *parser )
                                                            segmenter->GetPriorLabelImage()->GetLargestPossibleRegion() );
         for( ItM.GoToBegin(), ItP.GoToBegin(); !ItM.IsAtEnd(); ++ItM, ++ItP )
           {
-          if( ItM.Get() == segmenter->GetMaskLabel() && ItP.Get() == 0 )
+          if( ItM.Get() != itk::NumericTraits<LabelType>::ZeroValue() && ItP.Get() == 0 )
             {
             if( verbose )
               {
@@ -441,7 +441,7 @@ int AtroposSegmentation( itk::ants::CommandLineParser *parser )
                                                                     segmenter->GetMaskImage()->GetLargestPossibleRegion() );
         for( ItM.GoToBegin(); !ItM.IsAtEnd(); ++ItM )
           {
-          if( ItM.Get() == segmenter->GetMaskLabel() )
+          if( ItM.Get() != itk::NumericTraits<LabelType>::ZeroValue() )
             {
             RealType sumPriorProbability = 0.0;
             for( unsigned int n = 0; n < segmenter->GetNumberOfTissueClasses(); n++ )

--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.h
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.h
@@ -583,18 +583,6 @@ public:
   const MaskImageType * GetMaskImage() const;
 
   /**
-   * Set mask label function.  If a binary mask image is specified, only those
-   * input image voxels corresponding with mask image values equal to
-   * m_MaskLabel are used in estimating the bias field.  Default = 1.
-   */
-  itkSetMacro( MaskLabel, MaskLabelType );
-
-  /**
-   * Get mask label.
-   */
-  itkGetConstMacro( MaskLabel, MaskLabelType );
-
-  /**
    * Set the label propagation type.  Euclidean distance uses the Maurer distance
    * transform to calculate the distance transform image. Otherwise the fast
    * marching filter is used to produce the geodesic distance.  The former option
@@ -822,8 +810,6 @@ private:
   unsigned int m_MaximumNumberOfIterations;
   RealType     m_CurrentPosteriorProbability;
   RealType     m_ConvergenceThreshold;
-
-  MaskLabelType m_MaskLabel;
 
   std::vector<LikelihoodFunctionPointer> m_MixtureModelComponents;
   Array<RealType>                        m_MixtureModelProportions;

--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.hxx
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.hxx
@@ -38,6 +38,7 @@
 #include "itkLabelStatisticsImageFilter.h"
 #include "itkMinimumDecisionRule.h"
 #include "itkMultiplyImageFilter.h"
+#include "itkMaskImageFilter.h"
 #include "itkOtsuMultipleThresholdsCalculator.h"
 #include "itkSampleClassifierFilter.h"
 #include "itkSignedMaurerDistanceMapImageFilter.h"
@@ -67,8 +68,6 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
   this->m_ElapsedIterations = 0;
   this->m_CurrentPosteriorProbability = 0.0;
   this->m_ConvergenceThreshold = 0.001;
-
-  this->m_MaskLabel = NumericTraits<LabelType>::OneValue();
 
   this->m_InitializationStrategy = KMeans;
   this->m_InitialKMeansParameters.SetSize( 0 );
@@ -544,24 +543,14 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
       {
       if( this->GetMaskImage() )
         {
-        typedef BinaryThresholdImageFilter<ClassifiedImageType, ClassifiedImageType>
-          ThresholderType;
-        typename ThresholderType::Pointer thresholder = ThresholderType::New();
-        thresholder->SetInput( this->GetMaskImage() );
-        thresholder->SetLowerThreshold( this->m_MaskLabel );
-        thresholder->SetUpperThreshold( this->m_MaskLabel );
-        thresholder->SetInsideValue( 1 );
-        thresholder->SetOutsideValue( 0 );
-        thresholder->Update();
+        typedef MaskImageFilter<ClassifiedImageType, ClassifiedImageType,
+                                                     ClassifiedImageType> MaskerType;
+        typename MaskerType::Pointer masker = MaskerType::New();
+        masker->SetInput1( this->GetPriorLabelImage() );
+        masker->SetInput2( this->GetMaskImage() );
+        masker->Update();
 
-        typedef MultiplyImageFilter<ClassifiedImageType, ClassifiedImageType,
-                                    ClassifiedImageType> MultiplierType;
-        typename MultiplierType::Pointer multiplier = MultiplierType::New();
-        multiplier->SetInput1( this->GetPriorLabelImage() );
-        multiplier->SetInput2( thresholder->GetOutput() );
-        multiplier->Update();
-
-        this->SetNthOutput( 0, multiplier->GetOutput() );
+        this->SetNthOutput( 0, masker->GetOutput() );
         }
       else
         {
@@ -741,7 +730,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
     ItO.GoToBegin();
     while( !ItP.IsAtEnd() )
       {
-      if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItP.GetIndex() ) == this->m_MaskLabel )
+      if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItP.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
         {
         if( ItP.Get() > ItM.Get() )
           {
@@ -789,7 +778,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
 
     while( !ItP.IsAtEnd() )
       {
-      if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItP.GetIndex() ) == this->m_MaskLabel )
+      if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItP.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
         {
         if( ItM.Get() <= this->m_ProbabilityThreshold || ItS.Get() == 0.0 )
           {
@@ -836,7 +825,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
   for( ItI.GoToBegin(); !ItI.IsAtEnd(); ++ItI )
     {
     if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItI.GetIndex() )
-        == this->m_MaskLabel )
+        != NumericTraits<MaskLabelType>::ZeroValue() )
       {
       if( ItI.Get() < minValue )
         {
@@ -859,7 +848,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
   else
     {
     typename MaskImageType::Pointer maskImage =
-      AllocImage<MaskImageType>( this->GetOutput(), this->m_MaskLabel );
+      AllocImage<MaskImageType>( this->GetOutput(), NumericTraits<LabelType>::OneValue() );
     stats->SetLabelInput( maskImage );
     }
   stats->UseHistogramsOn();
@@ -869,7 +858,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
   typedef OtsuMultipleThresholdsCalculator<typename StatsType::HistogramType>
     OtsuType;
   typename OtsuType::Pointer otsu = OtsuType::New();
-  otsu->SetInputHistogram( stats->GetHistogram( this->m_MaskLabel ) );
+  otsu->SetInputHistogram( stats->GetHistogram( NumericTraits<LabelType>::OneValue() ) );
   otsu->SetNumberOfThresholds( this->m_NumberOfTissueClasses - 1 );
   otsu->Update();
 
@@ -880,7 +869,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
   for( ItI.GoToBegin(), ItO.GoToBegin(); !ItI.IsAtEnd(); ++ItI, ++ItO )
     {
     LabelType label = NumericTraits<LabelType>::ZeroValue();
-    if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItI.GetIndex() ) == this->m_MaskLabel )
+    if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItI.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
       {
       if( ItI.Get() < thresholds[0] )
         {
@@ -927,14 +916,14 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
   else
     {
     typename MaskImageType::Pointer maskImage =
-      AllocImage<MaskImageType>( this->GetOutput(), this->m_MaskLabel );
+      AllocImage<MaskImageType>( this->GetOutput(), NumericTraits<LabelType>::OneValue() );
     stats->SetLabelInput( maskImage );
     }
   stats->UseHistogramsOff();
   stats->Update();
 
-  RealType minValue = stats->GetMinimum( this->m_MaskLabel );
-  RealType maxValue = stats->GetMaximum( this->m_MaskLabel );
+  const RealType minValue = stats->GetMinimum( NumericTraits<LabelType>::OneValue() );
+  const RealType maxValue = stats->GetMaximum( NumericTraits<LabelType>::OneValue() );
 
   //
   // The code below can be replaced by itkListSampleToImageFilter when we
@@ -947,7 +936,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
                                                     this->GetInput()->GetRequestedRegion() );
   for( ItI.GoToBegin(); !ItI.IsAtEnd(); ++ItI )
     {
-    if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItI.GetIndex() ) == this->m_MaskLabel )
+    if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItI.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
       {
       typename SampleType::MeasurementVectorType measurement;
       measurement.SetSize( 1 );
@@ -1063,7 +1052,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
   LabelIterator it = classifier->GetOutput()->Begin();
   while( it != classifier->GetOutput()->End() )
     {
-    if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItO.GetIndex() ) == this->m_MaskLabel )
+    if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItO.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
       {
       ItO.Set( it.GetClassLabel() );
       ++it;
@@ -1115,7 +1104,8 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
     sample2->SetMeasurementVectorSize( this->m_NumberOfIntensityImages );
     for( ItO.GoToBegin(); !ItO.IsAtEnd(); ++ItO )
       {
-      if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItO.GetIndex() ) == this->m_MaskLabel )
+      if( !this->GetMaskImage() ||
+          this->GetMaskImage()->GetPixel( ItO.GetIndex() ) != NumericTraits<LabelType>::ZeroValue()  )
         {
         typename SampleType::MeasurementVectorType measurement;
         measurement.SetSize( this->m_NumberOfIntensityImages );
@@ -1202,7 +1192,8 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
     LabelIterator it2 = classifier->GetOutput()->Begin();
     while( it2 != classifier->GetOutput()->End() )
       {
-      if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItO.GetIndex() ) == this->m_MaskLabel )
+      if( !this->GetMaskImage() ||
+          this->GetMaskImage()->GetPixel( ItO.GetIndex() ) != NumericTraits<LabelType>::ZeroValue() )
         {
         ItO.Set( it2.GetClassLabel() );
         ++it2;
@@ -1318,7 +1309,8 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
     ItO.GoToBegin();
     while( !ItP.IsAtEnd() )
       {
-      if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItO.GetIndex() ) == this->m_MaskLabel )
+      if( !this->GetMaskImage() ||
+          this->GetMaskImage()->GetPixel( ItO.GetIndex() ) != NumericTraits<LabelType>::ZeroValue() )
         {
         RealType posteriorProbability = ItP.Get();
         weights.SetElement( count++, posteriorProbability );
@@ -1419,7 +1411,8 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
 //        weightedPriorProbabilityImage->GetRequestedRegion() );
 //      for( ItW.GoToBegin(); !ItW.IsAtEnd(); ++ItW )
 //        {
-//        if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItW.GetIndex() ) == this->m_MaskLabel )
+//        if( !this->GetMaskImage() ||
+//            this->GetMaskImage()->GetPixel( ItW.GetIndex() ) != NumericTraits<LabelType>::ZeroValue() )
 //          {
 //          RealType priorProbability = 0.0;
 //          if( this->m_InitializationStrategy == PriorLabelImage ||
@@ -1479,7 +1472,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
 //        weightedPriorProbabilityImage->GetRequestedRegion() );
 //      for( ItW.GoToBegin(); !ItW.IsAtEnd(); ++ItW )
 //        {
-//        if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItW.GetIndex() ) == this->m_MaskLabel )
+//        if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItW.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
 //          {
 //          RealType priorProbability = 0.0;
 //          if( this->m_InitializationStrategy == PriorLabelImage ||
@@ -1542,7 +1535,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
       maxPosteriorProbabilityImage->GetRequestedRegion() );
     for( ItM.GoToBegin(); !ItM.IsAtEnd(); ++ItM )
       {
-      if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItM.GetIndex() ) == this->m_MaskLabel )
+      if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItM.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
         {
         maxPosteriorSum += ItM.Get();
         }
@@ -1684,7 +1677,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
                                                          this->GetOutput()->GetRequestedRegion() );
   for( ItO.GoToBegin(); !ItO.IsAtEnd(); ++ItO )
     {
-    if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItO.GetIndex() ) == this->m_MaskLabel )
+    if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItO.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
       {
       for( unsigned int i = 0; i < this->m_NumberOfIntensityImages; i++ )
         {
@@ -2100,7 +2093,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
           this->m_SumPosteriorProbabilityImage->GetRequestedRegion() );
         for( ItO.GoToBegin(), ItS.GoToBegin(); !ItO.IsAtEnd(); ++ItO, ++ItS )
           {
-          if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItO.GetIndex() ) == this->m_MaskLabel )
+          if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItO.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
             {
             RealType mrfSmoothingFactor = this->m_MRFSmoothingFactor;
             if( this->m_MRFCoefficientImage )
@@ -2361,7 +2354,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
                                                           this->GetOutput(), this->GetOutput()->GetRequestedRegion() );
       for( ItO.GoToBegin(); !ItO.IsAtEnd(); ++ItO )
         {
-        if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItO.GetIndex() ) == this->m_MaskLabel )
+        if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItO.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
           {
           RealType mrfSmoothingFactor = this->m_MRFSmoothingFactor;
           if( this->m_MRFCoefficientImage )
@@ -2740,7 +2733,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
           distancePriorProbabilityImage->GetRequestedRegion() );
         for( ItD.GoToBegin(), ItS.GoToBegin(); !ItS.IsAtEnd(); ++ItD, ++ItS )
           {
-          if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItD.GetIndex() ) == this->m_MaskLabel )
+          if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItD.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
             {
             if( ItS.Get() <= this->m_ProbabilityThreshold )
               {
@@ -2763,7 +2756,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
             this->m_DistancePriorProbabilityImages[c]->GetRequestedRegion() );
           for( ItD.GoToBegin(), ItS.GoToBegin(); !ItS.IsAtEnd(); ++ItD, ++ItS )
             {
-            if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItD.GetIndex() ) == this->m_MaskLabel )
+            if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItD.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
               {
               if( ItS.Get() <= this->m_ProbabilityThreshold )
                 {
@@ -2945,7 +2938,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
         this->m_SumDistancePriorProbabilityImage->GetRequestedRegion() );
       for( ItD.GoToBegin(), ItS.GoToBegin(); !ItS.IsAtEnd(); ++ItD, ++ItS )
         {
-        if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItD.GetIndex() ) == this->m_MaskLabel )
+        if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItD.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
           {
           if( ItS.Get() <= this->m_ProbabilityThreshold )
             {
@@ -3030,7 +3023,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
                                                      probabilityImage->GetBufferedRegion() );
     for( ItP.GoToBegin(); !ItP.IsAtEnd(); ++ItP )
       {
-      if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItP.GetIndex() ) == this->m_MaskLabel )
+      if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( ItP.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
         {
         if( ItP.Get() >= 0.5 )
           {
@@ -3129,7 +3122,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
                                                   likelihoodImage->GetRequestedRegion() );
   for( It.GoToBegin(); !It.IsAtEnd(); ++It )
     {
-    if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( It.GetIndex() ) == this->m_MaskLabel )
+    if( !this->GetMaskImage() || this->GetMaskImage()->GetPixel( It.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() )
       {
       MeasurementVectorType measurement;
       measurement.SetSize( this->m_NumberOfIntensityImages );
@@ -3192,7 +3185,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
       {
       if( this->m_ICMCodeImage->GetPixel( It.GetIndex() ) == 0
           && ( !this->GetMaskImage() ||
-               this->GetMaskImage()->GetPixel( It.GetIndex() ) == this->m_MaskLabel ) )
+               this->GetMaskImage()->GetPixel( It.GetIndex() ) != NumericTraits<MaskLabelType>::ZeroValue() ) )
         {
         bool hasCode = false;
         for( unsigned int n = 0; n < neighborhoodSize; n++ )
@@ -3234,9 +3227,6 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
      << this->m_MaximumNumberOfIterations << std::endl;
   os << indent << "Convergence threshold: "
      << this->m_ConvergenceThreshold << std::endl;
-  os << indent << "Mask label: "
-     << static_cast<typename NumericTraits<LabelType>::PrintType>
-    ( this->m_MaskLabel ) << std::endl;
   os << indent << "Number of tissue classes: "
      << this->m_NumberOfTissueClasses << std::endl;
   os << indent << "Number of partial volume classes: "

--- a/ImageSegmentation/itkWeightedVotingFusionImageFilter.h
+++ b/ImageSegmentation/itkWeightedVotingFusionImageFilter.h
@@ -384,7 +384,6 @@ private:
   LabelImageList                                       m_AtlasSegmentations;
   LabelExclusionMap                                    m_LabelExclusionImages;
   MaskImagePointer                                     m_MaskImage;
-  LabelType                                            m_MaskLabel;
 
   typename CountImageType::Pointer                     m_CountImage;
 

--- a/ImageSegmentation/itkWeightedVotingFusionImageFilter.hxx
+++ b/ImageSegmentation/itkWeightedVotingFusionImageFilter.hxx
@@ -46,7 +46,6 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
   m_ConstrainSolutionToNonnegativeWeights( false )
 {
   this->m_MaskImage = ITK_NULLPTR;
-  this->m_MaskLabel = NumericTraits<LabelType>::OneValue();
 
   this->m_CountImage = ITK_NULLPTR;
 
@@ -245,7 +244,8 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
       this->m_AtlasSegmentations[i], this->m_AtlasSegmentations[i]->GetRequestedRegion() );
     for( It.GoToBegin(); !It.IsAtEnd(); ++It )
       {
-      if( !this->m_MaskImage || this->m_MaskImage->GetPixel( It.GetIndex() ) == this->m_MaskLabel )
+      if( !this->m_MaskImage ||
+          this->m_MaskImage->GetPixel( It.GetIndex() ) != NumericTraits<LabelType>::ZeroValue() )
         {
         this->m_LabelSet.insert( It.Get() );
         }
@@ -462,7 +462,8 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
 
     IndexType currentCenterIndex = ItN.GetIndex();
 
-    if( this->m_MaskImage && this->m_MaskImage->GetPixel( currentCenterIndex ) != this->m_MaskLabel )
+    if( this->m_MaskImage &&
+        this->m_MaskImage->GetPixel( currentCenterIndex ) == NumericTraits<LabelType>::ZeroValue() )
       {
       continue;
       }
@@ -659,7 +660,8 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
           continue;
           }
 
-        if( this->m_MaskImage && this->m_MaskImage->GetPixel( neighborhoodIndex ) != this->m_MaskLabel )
+        if( this->m_MaskImage &&
+            this->m_MaskImage->GetPixel( neighborhoodIndex ) == NumericTraits<LabelType>::ZeroValue() )
           {
           continue;
           }
@@ -744,7 +746,8 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
     {
     IndexType index = It.GetIndex();
 
-    if( this->m_MaskImage && this->m_MaskImage->GetPixel( It.GetIndex() ) != this->m_MaskLabel )
+    if( this->m_MaskImage &&
+        this->m_MaskImage->GetPixel( It.GetIndex() ) == NumericTraits<LabelType>::ZeroValue() )
       {
       continue;
       }

--- a/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.h
+++ b/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.h
@@ -109,9 +109,6 @@ public:
   itkSetObjectMacro( MaskImage, TMaskImage );
   itkSetObjectMacro( ConfidenceImage, TConfidenceImage );
 
-  itkSetMacro( MaskLabel, typename TMaskImage::PixelType );
-  itkGetConstMacro( MaskLabel, typename TMaskImage::PixelType );
-
   virtual MeasureType GetValue( const ParametersType & parameters ) const ITK_OVERRIDE;
 
   virtual void GetDerivative( const ParametersType & parameters, DerivativeType & derivative ) const ITK_OVERRIDE;
@@ -129,8 +126,6 @@ private:
   typename TBiasFieldImage::Pointer              m_BiasFieldImage;
   typename TMaskImage::Pointer                   m_MaskImage;
   typename TConfidenceImage::Pointer             m_ConfidenceImage;
-
-  typename TMaskImage::PixelType                 m_MaskLabel;
 };
 
 /**
@@ -217,9 +212,6 @@ public:
     this->SetConfidenceImage( image );
   }
 
-  itkSetMacro( MaskLabel, MaskPixelType );
-  itkGetConstMacro( MaskLabel, MaskPixelType );
-
   itkSetMacro( NumberOfHistogramBins, unsigned int );
   itkGetConstMacro( NumberOfHistogramBins, unsigned int );
 
@@ -287,8 +279,6 @@ private:
     typename RealImageType::Pointer );
   RealType CalculateOptimalBiasFieldScaling(
     typename RealImageType::Pointer );
-
-  MaskPixelType m_MaskLabel;
 
   /**
    * Parameters for deconvolution with Weiner filter

--- a/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.hxx
+++ b/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.hxx
@@ -43,8 +43,6 @@ N3BiasFieldScaleCostFunction<TInputImage, TBiasFieldImage, TMaskImage,
   this->m_BiasFieldImage = ITK_NULLPTR;
   this->m_MaskImage = ITK_NULLPTR;
   this->m_ConfidenceImage = ITK_NULLPTR;
-
-  this->m_MaskLabel = NumericTraits<typename TMaskImage::PixelType>::OneValue();
 }
 
 template <class TInputImage, class TBiasFieldImage, class TMaskImage,
@@ -73,7 +71,7 @@ N3BiasFieldScaleCostFunction<TInputImage, TBiasFieldImage, TMaskImage,
   for( ItI.GoToBegin(), ItB.GoToBegin(); !ItI.IsAtEnd(); ++ItI, ++ItB )
     {
     if( ( !this->m_MaskImage ||
-          this->m_MaskImage->GetPixel( ItI.GetIndex() ) == this->m_MaskLabel )
+          this->m_MaskImage->GetPixel( ItI.GetIndex() ) != NumericTraits<typename TMaskImage::PixelType>::ZeroValue() )
         && ( !this->m_ConfidenceImage ||
              this->m_ConfidenceImage->GetPixel( ItI.GetIndex() ) > 0.0 ) )
       {
@@ -88,7 +86,7 @@ N3BiasFieldScaleCostFunction<TInputImage, TBiasFieldImage, TMaskImage,
   for( ItI.GoToBegin(), ItB.GoToBegin(); !ItI.IsAtEnd(); ++ItI, ++ItB )
     {
     if( ( !this->m_MaskImage ||
-          this->m_MaskImage->GetPixel( ItI.GetIndex() ) == this->m_MaskLabel )
+          this->m_MaskImage->GetPixel( ItI.GetIndex() ) != NumericTraits<typename TMaskImage::PixelType>::ZeroValue() )
         && ( !this->m_ConfidenceImage ||
              this->m_ConfidenceImage->GetPixel( ItI.GetIndex() ) > 0.0 ) )
       {
@@ -120,7 +118,7 @@ N3BiasFieldScaleCostFunction<TInputImage, TBiasFieldImage, TMaskImage,
   for( ItI.GoToBegin(), ItB.GoToBegin(); !ItI.IsAtEnd(); ++ItI, ++ItB )
     {
     if( ( !this->m_MaskImage ||
-          this->m_MaskImage->GetPixel( ItI.GetIndex() ) == this->m_MaskLabel )
+          this->m_MaskImage->GetPixel( ItI.GetIndex() ) != NumericTraits<typename TMaskImage::PixelType>::ZeroValue() )
         && ( !this->m_ConfidenceImage ||
              this->m_ConfidenceImage->GetPixel( ItI.GetIndex() ) > 0.0 ) )
       {
@@ -139,7 +137,7 @@ N3BiasFieldScaleCostFunction<TInputImage, TBiasFieldImage, TMaskImage,
   for( ItI.GoToBegin(), ItB.GoToBegin(); !ItI.IsAtEnd(); ++ItI, ++ItB )
     {
     if( ( !this->m_MaskImage ||
-          this->m_MaskImage->GetPixel( ItI.GetIndex() ) == this->m_MaskLabel )
+          this->m_MaskImage->GetPixel( ItI.GetIndex() ) != NumericTraits<typename TMaskImage::PixelType>::ZeroValue() )
         && ( !this->m_ConfidenceImage ||
              this->m_ConfidenceImage->GetPixel( ItI.GetIndex() ) > 0.0 ) )
       {
@@ -174,8 +172,6 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
 ::N3MRIBiasFieldCorrectionImageFilter()
 {
   this->SetNumberOfRequiredInputs( 1 );
-
-  this->m_MaskLabel = NumericTraits<MaskPixelType>::OneValue();
 
   this->m_NumberOfHistogramBins = 200;
   this->m_WeinerFilterNoise = 0.01;
@@ -218,7 +214,7 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
   for( It.GoToBegin(); !It.IsAtEnd(); ++It )
     {
     if( ( !this->GetMaskImage() ||
-          this->GetMaskImage()->GetPixel( It.GetIndex() ) == this->m_MaskLabel )
+          this->GetMaskImage()->GetPixel( It.GetIndex() ) != NumericTraits<MaskPixelType>::ZeroValue() )
         && ( !this->GetConfidenceImage() ||
              this->GetConfidenceImage()->GetPixel( It.GetIndex() ) > 0.0 ) )
       {
@@ -333,7 +329,7 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
   for( ItU.GoToBegin(); !ItU.IsAtEnd(); ++ItU )
     {
     if( ( !this->GetMaskImage() ||
-          this->GetMaskImage()->GetPixel( ItU.GetIndex() ) == this->m_MaskLabel )
+          this->GetMaskImage()->GetPixel( ItU.GetIndex() ) != NumericTraits<MaskPixelType>::ZeroValue() )
         && ( !this->GetConfidenceImage() ||
              this->GetConfidenceImage()->GetPixel( ItU.GetIndex() ) > 0.0 ) )
       {
@@ -359,7 +355,7 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
   for( ItU.GoToBegin(); !ItU.IsAtEnd(); ++ItU )
     {
     if( ( !this->GetMaskImage() ||
-          this->GetMaskImage()->GetPixel( ItU.GetIndex() ) == this->m_MaskLabel )
+          this->GetMaskImage()->GetPixel( ItU.GetIndex() ) != NumericTraits<MaskPixelType>::ZeroValue() )
         && ( !this->GetConfidenceImage() ||
              this->GetConfidenceImage()->GetPixel( ItU.GetIndex() ) > 0.0 ) )
       {
@@ -515,7 +511,7 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
   for( ItU.GoToBegin(), ItC.GoToBegin(); !ItU.IsAtEnd(); ++ItU, ++ItC )
     {
     if( ( !this->GetMaskImage() ||
-          this->GetMaskImage()->GetPixel( ItU.GetIndex() ) == this->m_MaskLabel )
+          this->GetMaskImage()->GetPixel( ItU.GetIndex() ) != NumericTraits<MaskPixelType>::ZeroValue() )
         && ( !this->GetConfidenceImage() ||
              this->GetConfidenceImage()->GetPixel( ItU.GetIndex() ) > 0.0 ) )
       {
@@ -571,7 +567,7 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
   for( It.GoToBegin(); !It.IsAtEnd(); ++It )
     {
     if( ( !this->GetMaskImage() ||
-          this->GetMaskImage()->GetPixel( It.GetIndex() ) == this->m_MaskLabel )
+          this->GetMaskImage()->GetPixel( It.GetIndex() ) != NumericTraits<MaskPixelType>::ZeroValue() )
         && ( !this->GetConfidenceImage() ||
              this->GetConfidenceImage()->GetPixel( It.GetIndex() ) > 0.0 ) )
       {
@@ -660,7 +656,7 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
   for( It.GoToBegin(); !It.IsAtEnd(); ++It )
     {
     if( !this->GetMaskImage() ||
-        this->GetMaskImage()->GetPixel( It.GetIndex() ) == this->m_MaskLabel )
+        this->GetMaskImage()->GetPixel( It.GetIndex() ) != NumericTraits<MaskPixelType>::ZeroValue() )
       {
       RealType pixel = It.Get();
       N += 1.0;
@@ -749,8 +745,6 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
 {
   Superclass::PrintSelf( os, indent );
 
-  os << indent << "Mask label: "
-     << this->m_MaskLabel << std::endl;
   os << indent << "Number of histogram bins: "
      << this->m_NumberOfHistogramBins << std::endl;
   os << indent << "Weiner filter noise: "


### PR DESCRIPTION
When applying a masking operation, any non-zero value
in the image should be considered foreground.  This is
the behavior of the itkMaskImageFilter, and the
itkSpatialImageMaskObject filters.  This makes using
the same image (even an label map image with multiple
labels) appropriate across different uses (i.e. registration
and segmentation).

In all uses inside ANTs, this had been hard coded to the
forground being equal to a value of 1, and no cases were found
that allowed for changing the mask match value.  For masks that
have only values of zero and 1, backwards compatibility is preserved.

For uses where label maps or intensity images were used, this
changes behavior, but in a way that makes ants tools consistent with
other ITK based behaviors.