### PR TITLE
ENH: Modernizing vcl_ to std::

### DIFF
--- a/Examples/ANTS.cxx
+++ b/Examples/ANTS.cxx
@@ -232,7 +232,7 @@ private:
       }
 
     unsigned int numberOfLevels = static_cast<unsigned int>(
-        vcl_log( (double)maxSize / 32 ) / vcl_log( (double) 2 ) ) + 1;
+        std::log( (double)maxSize / 32 ) / std::log( (double) 2 ) ) + 1;
     std::string iterations( " -i " );
     for( int n = numberOfLevels; n > 0; n-- )
       {

--- a/Examples/Atropos.cxx
+++ b/Examples/Atropos.cxx
@@ -67,7 +67,7 @@ public:
     typedef typename TFilter::RealType RealType;
 
     RealType annealingTemperature = filter->GetInitialAnnealingTemperature()
-      * vcl_pow( filter->GetAnnealingRate(), static_cast<RealType>(
+      * std::pow( filter->GetAnnealingRate(), static_cast<RealType>(
                    filter->GetElapsedIterations() ) );
 
     annealingTemperature = vnl_math_max( annealingTemperature,

--- a/Examples/CreateTiledMosaic.cxx
+++ b/Examples/CreateTiledMosaic.cxx
@@ -613,16 +613,16 @@ int CreateMosaic( itk::ants::CommandLineParser *parser )
 
   if( numberOfRows <= 0 && numberOfColumns > 0 )
     {
-    numberOfRows = vcl_ceil( static_cast<float>( numberOfSlices ) / static_cast<float>( numberOfColumns ) );
+    numberOfRows = std::ceil( static_cast<float>( numberOfSlices ) / static_cast<float>( numberOfColumns ) );
     }
   else if( numberOfColumns <= 0 && numberOfRows > 0 )
     {
-    numberOfColumns = vcl_ceil( static_cast<float>( numberOfSlices ) / static_cast<float>( numberOfRows ) );
+    numberOfColumns = std::ceil( static_cast<float>( numberOfSlices ) / static_cast<float>( numberOfRows ) );
     }
   else if( numberOfColumns <= 0 && numberOfRows <= 0 )
     {
-    numberOfRows = static_cast<int>( vcl_sqrt( static_cast<float>( numberOfSlices ) ) );
-    numberOfColumns = vcl_ceil( static_cast<float>( numberOfSlices ) / static_cast<float>( numberOfRows ) );
+    numberOfRows = static_cast<int>( std::sqrt( static_cast<float>( numberOfSlices ) ) );
+    numberOfColumns = std::ceil( static_cast<float>( numberOfSlices ) / static_cast<float>( numberOfRows ) );
     }
 
   itk::ants::CommandLineParser::OptionType::Pointer flipOption =

--- a/Examples/ImageIntensityStatistics.cxx
+++ b/Examples/ImageIntensityStatistics.cxx
@@ -142,7 +142,7 @@ int ImageIntensityStatistics( int argc, char *argv[] )
         / static_cast<RealType>( histogram->GetTotalFrequency() );
       if ( p > 0 )
         {
-        entropy += ( -p * vcl_log( p ) / vcl_log( 2.0 ) );
+        entropy += ( -p * std::log( p ) / std::log( 2.0 ) );
         }
       }
 
@@ -159,7 +159,7 @@ int ImageIntensityStatistics( int argc, char *argv[] )
     RealType prefactor4 = vnl_math_sqr( N[index] ) / ( ( N[index] - 1.0 ) * ( N[index] - 2.0 ) * ( N[index] - 3.0 ) );
     RealType k4 = prefactor4 * ( ( N[index] + 1 ) * m4[index] - 3 * ( N[index] - 1 ) * vnl_math_sqr( m2 ) );
 
-    RealType skewness = k3 / vcl_sqrt( k2 * k2 * k2 );
+    RealType skewness = k3 / std::sqrt( k2 * k2 * k2 );
     RealType kurtosis = k4 / vnl_math_sqr( k2 );
 
     std::cout << std::setw( 8  ) << *it;

--- a/Examples/ImageMath.cxx
+++ b/Examples/ImageMath.cxx
@@ -4967,7 +4967,7 @@ int LabelSurfaceArea(int argc, char *argv[])
   voxspc = voxspc / static_cast<Scalar>( ImageDimension );
   Scalar voxspc2 = voxspc * voxspc;
   Scalar dm1 = static_cast<Scalar>( ImageDimension - 1 );
-  Scalar refarea = vcl_pow( static_cast<Scalar>( rad[1] ) , dm1 );
+  Scalar refarea = std::pow( static_cast<Scalar>( rad[1] ) , dm1 );
   iteratorType GHood(rad, input, input->GetLargestPossibleRegion() );
   GHood.GoToBegin();
   while( !GHood.IsAtEnd() )
@@ -5161,7 +5161,7 @@ int FitSphere(int argc, char *argv[])
         }
       cmdist=sqrt(cmdist);
       //          // std::cout << " GMT " << gmtotal << " WMT " << wmtotal << " dist " << cmdist << std::endl;
-  float gmrad=vcl_pow( 3.*gvol/(4.*pi) , 1./3.);
+  float gmrad=std::pow( 3.*gvol/(4.*pi) , 1./3.);
   float gwrat=0,gvrat=0;
   if (warea > 0) gwrat=garea/warea;
   if (wvol > 0) gvrat=gvol/wvol;
@@ -5403,7 +5403,7 @@ int ImageMath(int argc, char *argv[])
       }
     else if( strcmp(operation.c_str(), "^") == 0 )
       {
-      result = vcl_pow(pix1, pix2);
+      result = std::pow(pix1, pix2);
       }
     else if( strcmp(operation.c_str(), "exp") == 0 )
       {
@@ -10287,7 +10287,7 @@ int LabelThickness(      int argc, char *argv[])
     {
     volumeelement *= spacing[i];
     }
-  volumeelement = vcl_pow( static_cast<double>(  volumeelement ), static_cast<double>( 0.3333 ) );
+  volumeelement = std::pow( static_cast<double>(  volumeelement ), static_cast<double>( 0.3333 ) );
 
   vnl_vector<double> surface(maxlab + 1, 0);
   vnl_vector<double> volume(maxlab + 1, 0);
@@ -11885,8 +11885,8 @@ int CorrelationVoting( int argc, char *argv[] )
         targetVar /= (k - 1);
         imageVar /= (k - 1);
         float pearson =
-          ( product - k * targetMean * imageMean ) / ( (k - 1) * vcl_sqrt(targetVar) * vcl_sqrt(imageVar) );
-        weights.SetElement( i, vcl_fabs(pearson) );
+          ( product - k * targetMean * imageMean ) / ( (k - 1) * std::sqrt(targetVar) * std::sqrt(imageVar) );
+        weights.SetElement( i, std::fabs(pearson) );
         } // i >= nImages
       for( int i = 0; i < nImages; i++ )
         {
@@ -12130,7 +12130,7 @@ int PearsonCorrelation( int argc, char *argv[] )
   var1 /= (k - 1);
   var2 /= (k - 1);
 
-  float pearson = ( product - k * mean1 * mean2 ) / ( (k - 1) * vcl_sqrt(var1) * vcl_sqrt(var2) );
+  float pearson = ( product - k * mean1 * mean2 ) / ( (k - 1) * std::sqrt(var1) * std::sqrt(var2) );
   std::cout << pearson << std::endl;
 
   return 0;
@@ -12552,8 +12552,8 @@ int PMSmoothImage(int argc, char *argv[])
   typename FilterType::Pointer filter = FilterType::New();
   filter->SetInput( image1 );
   filter->SetNumberOfIterations( sigma );
-  PixelType mytimestep = spacingsize / vcl_pow( 2.0 , static_cast<double>(ImageDimension+1) );
-  PixelType reftimestep = 0.4 / vcl_pow( 2.0 , static_cast<double>(ImageDimension+1) );
+  PixelType mytimestep = spacingsize / std::pow( 2.0 , static_cast<double>(ImageDimension+1) );
+  PixelType reftimestep = 0.4 / std::pow( 2.0 , static_cast<double>(ImageDimension+1) );
   if ( mytimestep > reftimestep ) mytimestep = reftimestep;
   filter->SetTimeStep( mytimestep );
   filter->SetConductanceParameter( conductance ); // might need to change this
@@ -12657,7 +12657,7 @@ int InPaint(int argc, char *argv[])
   locPoint.Fill( 0 );
   while(!imageIterator.IsAtEnd())
     {
-    if ( ct == static_cast<unsigned int>( vcl_floor( (PixelType) kernelsize / 2.0 ) ) )
+    if ( ct == static_cast<unsigned int>( std::floor( (PixelType) kernelsize / 2.0 ) ) )
       {
       kernel->TransformIndexToPhysicalPoint(  imageIterator.GetIndex(), centerPoint );
       }
@@ -12683,7 +12683,7 @@ int InPaint(int argc, char *argv[])
       imageIterator.Set( 1.0 / val );
       totalval += imageIterator.Get( );
       }
-    if ( ct2 == static_cast<unsigned int>( vcl_floor( (PixelType) ct / 2.0 ) ) ) imageIterator.Set( 1.e-8 );
+    if ( ct2 == static_cast<unsigned int>( std::floor( (PixelType) ct / 2.0 ) ) ) imageIterator.Set( 1.e-8 );
     ++ct2;
     ++imageIterator;
     }
@@ -12771,7 +12771,7 @@ int InPaint2(int argc, char *argv[])
   typename ImageType::PointType locPoint;
   while(!imageIterator.IsAtEnd())
     {
-    if ( ct == static_cast<unsigned int>( vcl_floor( (PixelType) kernelsize / 2.0 ) ) )
+    if ( ct == static_cast<unsigned int>( std::floor( (PixelType) kernelsize / 2.0 ) ) )
       {
       kernel->TransformIndexToPhysicalPoint(  imageIterator.GetIndex(), centerPoint );
       }
@@ -12797,7 +12797,7 @@ int InPaint2(int argc, char *argv[])
       imageIterator.Set( 1.0 / val );
       totalval += imageIterator.Get( );
       }
-    if ( ct2 == static_cast<unsigned int>( vcl_floor( (PixelType) ct / 2.0 ) ) ) imageIterator.Set( 1.e-8 );
+    if ( ct2 == static_cast<unsigned int>( std::floor( (PixelType) ct / 2.0 ) ) ) imageIterator.Set( 1.e-8 );
     ++ct2;
     ++imageIterator;
     }
@@ -13185,8 +13185,8 @@ int BlobDetector( int argc, char *argv[] )
   // sensitive parameters are set here - begin
   RealType     gradsig = 1.0;      // sigma for gradient filter
   unsigned int stepsperoctave = 10; // number of steps between doubling of scale
-  RealType     minscale = vcl_pow( 1.0, 1.0 );
-  RealType     maxscale = vcl_pow( 2.0, 10.0 );
+  RealType     minscale = std::pow( 1.0, 1.0 );
+  RealType     maxscale = std::pow( 2.0, 10.0 );
   RealType     uniqfeat_thresh = 0.01;
   RealType     smallval = 1.e-2; // assumes images are normalizes in [ 0, 1 ]
   bool         dosinkhorn = false;

--- a/Examples/LabelGeometryMeasures.cxx
+++ b/Examples/LabelGeometryMeasures.cxx
@@ -293,12 +293,12 @@ unsigned int GetNumberOfLabelVoxelsInUpperRightQuadrant( TransformType *affineTr
   typename RegionType::SizeType size;
   for( unsigned int d = 0; d < LabelImageType::ImageDimension; d++ )
     {
-    index[d] = vcl_floor( resampler->GetOutput()->GetLargestPossibleRegion().GetIndex()[d] + 0.5 * resampler->GetOutput()->GetLargestPossibleRegion().GetSize()[d] );
-    size[d] = vcl_floor( 0.5 * resampler->GetOutput()->GetLargestPossibleRegion().GetSize()[d] );
+    index[d] = std::floor( resampler->GetOutput()->GetLargestPossibleRegion().GetIndex()[d] + 0.5 * resampler->GetOutput()->GetLargestPossibleRegion().GetSize()[d] );
+    size[d] = std::floor( 0.5 * resampler->GetOutput()->GetLargestPossibleRegion().GetSize()[d] );
     }
 
-  index[1] = vcl_floor( resampler->GetOutput()->GetLargestPossibleRegion().GetIndex()[1] );
-  size[1] = vcl_floor( resampler->GetOutput()->GetLargestPossibleRegion().GetSize()[1] );
+  index[1] = std::floor( resampler->GetOutput()->GetLargestPossibleRegion().GetIndex()[1] );
+  size[1] = std::floor( resampler->GetOutput()->GetLargestPossibleRegion().GetSize()[1] );
 
   RegionType region;
   region.SetIndex( index );

--- a/Examples/N4BiasFieldCorrection.cxx
+++ b/Examples/N4BiasFieldCorrection.cxx
@@ -238,7 +238,7 @@ int N4( itk::ants::CommandLineParser *parser )
           {
           float domain = static_cast<RealType>( originalImageSize[d] - 1 ) * inputImage->GetSpacing()[d];
           unsigned int numberOfSpans = static_cast<unsigned int>(
-              vcl_ceil( domain / splineDistance ) );
+              std::ceil( domain / splineDistance ) );
           unsigned long extraPadding = static_cast<unsigned long>( ( numberOfSpans
                                                                      * splineDistance
                                                                      - domain ) / inputImage->GetSpacing()[d] + 0.5 );

--- a/Examples/SmoothDisplacementField.cxx
+++ b/Examples/SmoothDisplacementField.cxx
@@ -204,13 +204,13 @@ int SmoothDisplacementField( int argc, char *argv[] )
     rmse += ( fieldIt.Get() - smoothedFieldIt.Get() ).GetSquaredNorm();
     N += 1.0;
     }
-  rmse = vcl_sqrt( rmse / N );
+  rmse = std::sqrt( rmse / N );
 
   std::cout << "Elapsed time: " << elapsedTime << std::endl;
   std::cout << "RMSE = " << rmse << std::endl;
   for( unsigned int d = 0; d < ImageDimension; d++ )
     {
-    std::cout << "  rmse[" << d << "] = " << vcl_sqrt( rmse_comp[d] / N ) << std::endl;
+    std::cout << "  rmse[" << d << "] = " << std::sqrt( rmse_comp[d] / N ) << std::endl;
     }
 
   WriteImage<DisplacementFieldType>( smoothField, argv[3] );

--- a/Examples/TileImages.cxx
+++ b/Examples/TileImages.cxx
@@ -94,16 +94,16 @@ int CreateMosaic( unsigned int argc, char *argv[] )
 
   if( numberOfRows <= 0 && numberOfColumns > 0 )
     {
-    numberOfRows = vcl_ceil( static_cast<float>( numberOfSlices ) / static_cast<float>( numberOfColumns ) );
+    numberOfRows = std::ceil( static_cast<float>( numberOfSlices ) / static_cast<float>( numberOfColumns ) );
     }
   else if( numberOfColumns <= 0 && numberOfRows > 0 )
     {
-    numberOfColumns = vcl_ceil( static_cast<float>( numberOfSlices ) / static_cast<float>( numberOfRows ) );
+    numberOfColumns = std::ceil( static_cast<float>( numberOfSlices ) / static_cast<float>( numberOfRows ) );
     }
   else if( numberOfColumns <= 0 && numberOfRows <= 0 )
     {
-    numberOfRows = static_cast<int>( vcl_sqrt( static_cast<float>( numberOfSlices ) ) );
-    numberOfColumns = vcl_ceil( static_cast<float>( numberOfSlices ) / static_cast<float>( numberOfRows ) );
+    numberOfRows = static_cast<int>( std::sqrt( static_cast<float>( numberOfSlices ) ) );
+    numberOfColumns = std::ceil( static_cast<float>( numberOfSlices ) / static_cast<float>( numberOfRows ) );
     }
 
   std::cout << "Slices[" << layout[0] << "]: " << numberOfSlices << std::endl;

--- a/Examples/antsAffineInitializer.cxx
+++ b/Examples/antsAffineInitializer.cxx
@@ -273,7 +273,7 @@ int antsAffineInitializerImp(int argc, char *argv[])
   RealType bestscale =
     calculator2->GetTotalMass() / calculator1->GetTotalMass();
   RealType powlev = 1.0 / static_cast<RealType>(ImageDimension);
-  bestscale = vcl_pow( bestscale , powlev );
+  bestscale = std::pow( bestscale , powlev );
   bestscale=1;
   unsigned int eigind1 = 1;
   unsigned int eigind2 = 1;

--- a/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
+++ b/Examples/antsRegistrationOptimizerCommandIterationUpdate.h
@@ -151,7 +151,7 @@ public:
                      << std::scientific << std::setprecision(12) << this->m_Optimizer->GetConvergenceValue() << ", "
                      << std::setprecision(4) << now << ", "
                      << std::setprecision(4) << (now - this->m_lastTotalTime)  << ", ";
-      if( ( this->m_ComputeFullScaleCCInterval != 0 ) && vcl_fabs(metricValue) > 1e-7 )
+      if( ( this->m_ComputeFullScaleCCInterval != 0 ) && std::fabs(metricValue) > 1e-7 )
         {
         this->Logger() << std::scientific << std::setprecision(12) << metricValue
                        << std::flush << std::endl;

--- a/Examples/antsSliceRegularizedRegistration.cxx
+++ b/Examples/antsSliceRegularizedRegistration.cxx
@@ -765,7 +765,7 @@ int ants_slice_regularized_registration( itk::ants::CommandLineParser *parser )
     A(z,0) = zz;
     for ( unsigned int lcol = 1; lcol < A.cols(); lcol++ )
       {
-      A( z, lcol ) = vcl_pow( zz, static_cast<RealType>(lcol+1) );
+      A( z, lcol ) = std::pow( zz, static_cast<RealType>(lcol+1) );
       }
     }
   for ( unsigned int lcol = 0; lcol < A.cols(); lcol++ )
@@ -810,7 +810,7 @@ int ants_slice_regularized_registration( itk::ants::CommandLineParser *parser )
   for ( unsigned int i = 0; i < transformList.size(); i++)
     {
     typename TranslationTransformType::ParametersType p = transformList[i]->GetParameters();
-    err += vcl_sqrt( vcl_pow( p[0] - solnx[i] , 2.0 ) + vcl_pow( p[1] - solny[i] , 2.0 ) );
+    err += std::sqrt( std::pow( p[0] - solnx[i] , 2.0 ) + std::pow( p[1] - solny[i] , 2.0 ) );
     p[ 0 ] = solnx[i] * eulerparam + p[0] * (1.0 - eulerparam);
     p[ 1 ] = solny[i] * eulerparam + p[1] * (1.0 - eulerparam);
     param_values(i,0) = p[0];

--- a/Examples/antsUtilitiesTesting.cxx
+++ b/Examples/antsUtilitiesTesting.cxx
@@ -117,8 +117,8 @@ private:
     std::cerr << "The scale parameters were improperly specified.  See usage." << std::endl;
     return EXIT_FAILURE;
     }
-  double scaleLowerBoundLog = vcl_log( scaleParameters[0] );
-  double scaleUpperBoundLog = vcl_log( scaleParameters[1] );
+  double scaleLowerBoundLog = std::log( scaleParameters[0] );
+  double scaleUpperBoundLog = std::log( scaleParameters[1] );
   unsigned int scaleNumberOfSamples = static_cast<unsigned int>( scaleParameters[2] );
   double scaleDelta = ( scaleUpperBoundLog - scaleLowerBoundLog ) / static_cast<double>( scaleNumberOfSamples - 1 );
 
@@ -232,13 +232,13 @@ private:
     for( double angle = 0.0; angle < 2.0 * vnl_math::pi; angle += rotationDelta )
       {
       AffineTransformType::MatrixType rotationMatrix;
-      rotationMatrix( 0, 0 ) = rotationMatrix( 1, 1 ) = vcl_cos( angle );
-      rotationMatrix( 1, 0 ) = vcl_sin( angle );
+      rotationMatrix( 0, 0 ) = rotationMatrix( 1, 1 ) = std::cos( angle );
+      rotationMatrix( 1, 0 ) = std::sin( angle );
       rotationMatrix( 0, 1 ) = -rotationMatrix( 1, 0 );
 
       for( double scaleLog = scaleLowerBoundLog; scaleLog <= scaleUpperBoundLog; scaleLog += scaleDelta )
         {
-        double scale = vcl_exp( scaleLog );
+        double scale = std::exp( scaleLog );
 
         SimilarityTransformType::Pointer similarityTransform = SimilarityTransformType::New();
         similarityTransform->SetCenter( initialTransform->GetCenter() );

--- a/Examples/compareTwoTransforms.cxx
+++ b/Examples/compareTwoTransforms.cxx
@@ -4,7 +4,9 @@
 #include "itkantsReadWriteTransform.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkBSplineTransform.h"
-#include <vcl_algorithm.h>
+#include <vcl_compiler.h>
+#include <iostream>
+#include <algorithm>
 
 #include "antsUtilities.h"
 

--- a/Examples/iMathFunctions.hxx
+++ b/Examples/iMathFunctions.hxx
@@ -59,8 +59,8 @@ BlobCorrespondence( typename ImageType::Pointer image, unsigned int nBlobs,
   // sensitive parameters are set here - begin
   //RealType     gradsig = 1.0;      // sigma for gradient filter
   unsigned int stepsperoctave = 10; // number of steps between doubling of scale
-  RealType     minscale = vcl_pow( 1.0, 1.0 );
-  RealType     maxscale = vcl_pow( 2.0, 10.0 );
+  RealType     minscale = std::pow( 1.0, 1.0 );
+  RealType     maxscale = std::pow( 2.0, 10.0 );
   //RealType     uniqfeat_thresh = 0.01;
   //RealType     smallval = 1.e-2; // assumes images are normalizes in [ 0, 1 ]
   //bool         dosinkhorn = false;
@@ -79,8 +79,8 @@ iMathBlobDetector( typename ImageType::Pointer image, unsigned int nBlobs )
   typedef float RealType;
 
   unsigned int stepsperoctave = 10; // number of steps between doubling of scale
-  RealType     minscale = vcl_pow( 1.0, 1.0 );
-  RealType     maxscale = vcl_pow( 2.0, 10.0 );
+  RealType     minscale = std::pow( 1.0, 1.0 );
+  RealType     maxscale = std::pow( 2.0, 10.0 );
 
   typedef itk::MultiScaleLaplacianBlobDetectorImageFilter<ImageType> BlobFilterType;
   typename BlobFilterType::Pointer blobFilter = BlobFilterType::New();
@@ -854,8 +854,8 @@ iMathPeronaMalik( typename ImageType::Pointer image, unsigned long nIterations,
 
   // FIXME - cite reason for this step
   double dimPlusOne = ImageType::ImageDimension + 1;
-  TimeStepType mytimestep = spacingsize / vcl_pow( 2.0 , dimPlusOne );
-  TimeStepType reftimestep = 0.4 / vcl_pow( 2.0 , dimPlusOne );
+  TimeStepType mytimestep = spacingsize / std::pow( 2.0 , dimPlusOne );
+  TimeStepType reftimestep = 0.4 / std::pow( 2.0 , dimPlusOne );
   if ( mytimestep > reftimestep )
     {
     mytimestep = reftimestep;

--- a/Examples/itkantsRegistrationHelper.hxx
+++ b/Examples/itkantsRegistrationHelper.hxx
@@ -3469,7 +3469,7 @@ RegistrationHelper<TComputeType, VImageDimension>
     {
     RealType domain = static_cast<RealType>(
       inputImage->GetLargestPossibleRegion().GetSize()[d] - 1 ) * inputImage->GetSpacing()[d];
-    meshSize.push_back( static_cast<unsigned int>( vcl_ceil( domain / knotSpacing ) ) );
+    meshSize.push_back( static_cast<unsigned int>( std::ceil( domain / knotSpacing ) ) );
 //     unsigned long extraPadding = static_cast<unsigned long>(
 //       ( numberOfSpans * splineDistance - domain ) / inputImage->GetSpacing()[d] + 0.5 );
 //     lowerBound[d] = static_cast<unsigned long>( 0.5 * extraPadding );

--- a/ImageRegistration/itkANTSAffine3DTransform.hxx
+++ b/ImageRegistration/itkANTSAffine3DTransform.hxx
@@ -11,7 +11,7 @@ template <class TScalarType>
 ANTSAffine3DTransform<TScalarType>::ANTSAffine3DTransform() :
   Superclass(ParametersDimension)
 {
-  m_Rotation = VnlQuaternionType(0, 0, 0, 1);   // axis * vcl_sin(t/2), vcl_cos(t/2)
+  m_Rotation = VnlQuaternionType(0, 0, 0, 1);   // axis * std::sin(t/2), std::cos(t/2)
   m_S1 = NumericTraits<TScalarType>::OneValue();
   m_S2 = NumericTraits<TScalarType>::OneValue();
   m_S3 = NumericTraits<TScalarType>::OneValue();
@@ -26,7 +26,7 @@ ANTSAffine3DTransform<TScalarType>::ANTSAffine3DTransform(unsigned int outputSpa
                                                           unsigned int parametersDimension) :
   Superclass(outputSpaceDimension, parametersDimension)
 {
-  m_Rotation = VnlQuaternionType(0, 0, 0, 1);   // axis * vcl_sin(t/2), vcl_cos(t/2)
+  m_Rotation = VnlQuaternionType(0, 0, 0, 1);   // axis * std::sin(t/2), std::cos(t/2)
   m_S1 = NumericTraits<TScalarType>::OneValue();
   m_S2 = NumericTraits<TScalarType>::OneValue();
   m_S3 = NumericTraits<TScalarType>::OneValue();

--- a/ImageRegistration/itkANTSCenteredAffine2DTransform.hxx
+++ b/ImageRegistration/itkANTSCenteredAffine2DTransform.hxx
@@ -127,7 +127,7 @@ ANTSCenteredAffine2DTransform<TScalarType>
 //    std::cout << "R=" << R << std::endl;
 //    std::cout << "dq=" << dq << std::endl;
 
-  m_Angle = vcl_acos(R[0][0]);
+  m_Angle = std::acos(R[0][0]);
 
   if( this->GetMatrix()[1][0] < 0.0 )
     {
@@ -246,7 +246,7 @@ void
 ANTSCenteredAffine2DTransform<TScalarType>
 ::SetAngleInDegrees(TScalarType angle)
 {
-  const TScalarType angleInRadians = angle * vcl_atan(1.0) / 45.0;
+  const TScalarType angleInRadians = angle * std::atan(1.0) / 45.0;
 
   this->SetAngle( angleInRadians );
 }
@@ -257,8 +257,8 @@ void
 ANTSCenteredAffine2DTransform<TScalarType>
 ::ComputeMatrix( void )
 {
-  const double ca = vcl_cos(m_Angle );
-  const double sa = vcl_sin(m_Angle );
+  const double ca = std::cos(m_Angle );
+  const double sa = std::sin(m_Angle );
 
   const double s1 = m_S1;
   const double s2 = m_S2;
@@ -360,8 +360,8 @@ GetParameters( void ) const
 // GetJacobian( const InputPointType & p ) const
 // {
 //
-//    const double ca = vcl_cos(this->GetAngle() );
-//    const double sa = vcl_sin(this->GetAngle() );
+//    const double ca = std::cos(this->GetAngle() );
+//    const double sa = std::sin(this->GetAngle() );
 //    const double s1 = m_S1;
 //    const double s2 = m_S2;
 //    const double k = m_K;
@@ -420,8 +420,8 @@ void
 ANTSCenteredAffine2DTransform<TScalarType>::ComputeJacobianWithRespectToParameters(const InputPointType  & p,
                                                                                    JacobianType & j) const
 {
-  const double ca = vcl_cos(this->GetAngle() );
-  const double sa = vcl_sin(this->GetAngle() );
+  const double ca = std::cos(this->GetAngle() );
+  const double sa = std::sin(this->GetAngle() );
   const double s1 = m_S1;
   const double s2 = m_S2;
   const double k = m_K;

--- a/ImageRegistration/itkANTSImageRegistrationOptimizer.h
+++ b/ImageRegistration/itkANTSImageRegistrationOptimizer.h
@@ -250,12 +250,12 @@ public:
           for( unsigned int d = 0; d < ImageDimension; d++ )
             {
             meshSize[d] *= static_cast<unsigned int>(
-                vcl_pow( 2.0, static_cast<int>( this->m_CurrentLevel ) ) );
+                std::pow( 2.0, static_cast<int>( this->m_CurrentLevel ) ) );
             }
           }
         else
           {
-          TReal spanLength = vcl_sqrt( this->m_GradSmoothingparam
+          TReal spanLength = std::sqrt( this->m_GradSmoothingparam
                                        / bsplineKernelVariance );
           for( unsigned int d = 0; d < ImageDimension; d++ )
             {
@@ -275,12 +275,12 @@ public:
           for( unsigned int d = 0; d < ImageDimension; d++ )
             {
             meshSize[d] *= static_cast<unsigned int>(
-                vcl_pow( 2.0, static_cast<int>( this->m_CurrentLevel ) ) );
+                std::pow( 2.0, static_cast<int>( this->m_CurrentLevel ) ) );
             }
           }
         else
           {
-          TReal spanLength = vcl_sqrt( this->m_TotalSmoothingparam
+          TReal spanLength = std::sqrt( this->m_TotalSmoothingparam
                                        / bsplineKernelVariance );
           for( unsigned int d = 0; d < ImageDimension; d++ )
             {
@@ -1284,7 +1284,7 @@ public:
 
       if( this->m_SubsamplingFactors.Size() == 0 )
         {
-        this->m_ScaleFactor = vcl_pow( 2.0, (int)static_cast<RealType>( this->m_NumberOfLevels - currentLevel - 1 ) );
+        this->m_ScaleFactor = std::pow( 2.0, (int)static_cast<RealType>( this->m_NumberOfLevels - currentLevel - 1 ) );
         }
       else
         {

--- a/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.cxx
+++ b/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.cxx
@@ -495,9 +495,9 @@ AvantsMutualInformationRegistrationFunction<TFixedImage, TMovingImage, TDisplace
   const double eps = 1.e-16;
   if( jointPDFValue > eps &&  (fixedImagePDFValue) > 0 )
     {
-    const double pRatio = vcl_log(jointPDFValue) - vcl_log(fixedImagePDFValue);
+    const double pRatio = std::log(jointPDFValue) - std::log(fixedImagePDFValue);
     const double term1 = dJPDF * pRatio;
-    const double term2 = vcl_log( (double)2) * dFmPDF * jointPDFValue / fixedImagePDFValue;
+    const double term2 = std::log( (double)2) * dFmPDF * jointPDFValue / fixedImagePDFValue;
     value =  (term2 - term1);
     }  // end if-block to check non-zero bin contribution
   else
@@ -535,9 +535,9 @@ AvantsMutualInformationRegistrationFunction<TFixedImage, TMovingImage, TDisplace
   const double eps = 1.e-16;
   if( jointPDFValue > eps &&  (movingImagePDFValue) > 0 )
     {
-    const double pRatio = vcl_log(jointPDFValue) - vcl_log(movingImagePDFValue);
+    const double pRatio = std::log(jointPDFValue) - std::log(movingImagePDFValue);
     const double term1 = dJPDF * pRatio;
-    const double term2 = vcl_log( (double)2) * dMmPDF * jointPDFValue / movingImagePDFValue;
+    const double term2 = std::log( (double)2) * dMmPDF * jointPDFValue / movingImagePDFValue;
     value =  (term2 - term1);
     } // end if-block to check non-zero bin contribution
   else

--- a/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.h
+++ b/ImageRegistration/itkAvantsMutualInformationRegistrationFunction.h
@@ -13,7 +13,9 @@
 =========================================================================*/
 #ifndef __itkAvantsMutualInformationRegistrationFunction_h
 #define __itkAvantsMutualInformationRegistrationFunction_h
-#include "vcl_cmath.h"
+#include <vcl_compiler.h>
+#include <iostream>
+#include "cmath"
 #include "itkImageFileWriter.h"
 #include "itkImageToImageMetric.h"
 #include "itkAvantsPDEDeformableRegistrationFunction.h"
@@ -475,7 +477,7 @@ public:
           if( pxy / denom > 0 )
             {
             // true mi
-            mi = pxy * vcl_log(pxy / denom);
+            mi = pxy * std::log(pxy / denom);
             // test mi
             // mi = 1.0 + log(pxy/denom);
             ct++;
@@ -487,8 +489,8 @@ public:
       //      std::cout << " II " << ii << " JJ " << ii << " pxy " << pxy << " px " << px << std::endl;
       }
     // GS: temp edit to make sure if this is decreasing (should be )
-    // this->m_Energy = -1.0*mival/vcl_log((double)2.0);
-    this->m_Energy = -1.0 * mival / vcl_log( (double)2.0);
+    // this->m_Energy = -1.0*mival/std::log((double)2.0);
+    this->m_Energy = -1.0 * mival / std::log( (double)2.0);
     return this->m_Energy;
   }
 

--- a/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.hxx
+++ b/ImageRegistration/itkExpectationBasedPointSetRegistrationFunction.hxx
@@ -522,7 +522,7 @@ ExpectationBasedPointSetRegistrationFunction<TFixedImage, TMovingImage, TDisplac
     {
     m_Metric = m_SumOfSquaredDifference
       / static_cast<double>( m_NumberOfPixelsProcessed );
-    m_RMSChange = vcl_sqrt( m_SumOfSquaredChange
+    m_RMSChange = std::sqrt( m_SumOfSquaredChange
                             / static_cast<double>( m_NumberOfPixelsProcessed ) );
     }
 
@@ -829,7 +829,7 @@ ExpectationBasedPointSetRegistrationFunction<TFixedImage, TMovingImage, TDisplac
           distance += vnl_math_sqr( ItM.Value()[d] + vector[d]
             - ItF.Value()[d] );
           }
-        this->m_Energy += ItW.Value() * vcl_sqrt( distance );
+        this->m_Energy += ItW.Value() * std::sqrt( distance );
 
         ++ItF;
         ++ItFD;

--- a/ImageRegistration/itkJensenHavrdaCharvatTsallisLabeledPointSetMetric.hxx
+++ b/ImageRegistration/itkJensenHavrdaCharvatTsallisLabeledPointSetMetric.hxx
@@ -350,7 +350,7 @@ JensenHavrdaCharvatTsallisLabeledPointSetMetric<TPointSet>
         {
         norm += ( labelDerivative(i, j) * labelDerivative(i, j) );
         }
-      avgNorm += vcl_sqrt( norm );
+      avgNorm += std::sqrt( norm );
       }
     avgNorm /= static_cast<RealType>( metric->GetNumberOfValues() );
     labelDerivative /= avgNorm;
@@ -517,7 +517,7 @@ JensenHavrdaCharvatTsallisLabeledPointSetMetric<TPointSet>
         {
         norm += ( labelDerivative(i, j) * labelDerivative(i, j) );
         }
-      avgNorm += vcl_sqrt( norm );
+      avgNorm += std::sqrt( norm );
       }
     avgNorm /= static_cast<RealType>( metric->GetNumberOfValues() );
     labelDerivative /= avgNorm;

--- a/ImageRegistration/itkJensenHavrdaCharvatTsallisPointSetMetric.hxx
+++ b/ImageRegistration/itkJensenHavrdaCharvatTsallisPointSetMetric.hxx
@@ -238,11 +238,11 @@ JensenHavrdaCharvatTsallisPointSetMetric<TPointSet>
 
     if( this->m_Alpha == 1.0 )
       {
-      energyTerm1 += vcl_log( probabilityStar );
+      energyTerm1 += std::log( probabilityStar );
       }
     else
       {
-      energyTerm1 += vcl_pow( probabilityStar,
+      energyTerm1 += std::pow( probabilityStar,
                               static_cast<RealType>( this->m_Alpha - 1.0 ) );
       }
     ++It;
@@ -282,11 +282,11 @@ JensenHavrdaCharvatTsallisPointSetMetric<TPointSet>
 
       if( this->m_Alpha == 1.0 )
         {
-        energyTerm2 += ( prefactor2 * vcl_log( probability ) );
+        energyTerm2 += ( prefactor2 * std::log( probability ) );
         }
       else
         {
-        energyTerm2 += ( prefactor2 * vcl_pow( probability,
+        energyTerm2 += ( prefactor2 * std::pow( probability,
                                                static_cast<RealType>( this->m_Alpha - 1.0 ) ) );
         }
       ++It;
@@ -403,7 +403,7 @@ JensenHavrdaCharvatTsallisPointSetMetric<TPointSet>
       continue;
       }
 
-    RealType probabilityStarFactor = vcl_pow( probabilityStar,
+    RealType probabilityStarFactor = std::pow( probabilityStar,
                                               static_cast<RealType>( 2.0 - this->m_Alpha ) );
 
     typename GaussianType::MeasurementVectorType sampleMeasurement;
@@ -476,7 +476,7 @@ JensenHavrdaCharvatTsallisPointSetMetric<TPointSet>
         continue;
         }
 
-      RealType probabilityFactor = vcl_pow( probability,
+      RealType probabilityFactor = std::pow( probability,
                                             static_cast<RealType>( 2.0 - this->m_Alpha ) );
       probabilityFactor *= ( samples[1]->GetNumberOfPoints()
                              / totalNumberOfSamples );
@@ -643,15 +643,15 @@ JensenHavrdaCharvatTsallisPointSetMetric<TPointSet>
 
     if( this->m_Alpha == 1.0 )
       {
-      energyTerm1 += ( prefactor[0] * vcl_log( probabilityStar ) );
+      energyTerm1 += ( prefactor[0] * std::log( probabilityStar ) );
       }
     else
       {
-      energyTerm1 += ( prefactor[0] * vcl_pow( probabilityStar,
+      energyTerm1 += ( prefactor[0] * std::pow( probabilityStar,
                                                static_cast<RealType>( this->m_Alpha - 1.0 ) ) );
       }
 
-    RealType probabilityStarFactor = vcl_pow( probabilityStar,
+    RealType probabilityStarFactor = std::pow( probabilityStar,
                                               static_cast<RealType>( 2.0 - this->m_Alpha ) );
 
     typename GaussianType::MeasurementVectorType sampleMeasurement;
@@ -740,15 +740,15 @@ JensenHavrdaCharvatTsallisPointSetMetric<TPointSet>
 
       if( this->m_Alpha == 1.0 )
         {
-        energyTerm2 += ( prefactor2[0] * vcl_log( probability ) );
+        energyTerm2 += ( prefactor2[0] * std::log( probability ) );
         }
       else
         {
-        energyTerm2 += ( prefactor2[0] * vcl_pow( probability,
+        energyTerm2 += ( prefactor2[0] * std::pow( probability,
                                                   static_cast<RealType>( this->m_Alpha - 1.0 ) ) );
         }
 
-      RealType probabilityFactor = vcl_pow( probability,
+      RealType probabilityFactor = std::pow( probability,
                                             static_cast<RealType>( 2.0 - this->m_Alpha ) );
       probabilityFactor *= ( samples[1]->GetNumberOfPoints()
                              / totalNumberOfSamples );

--- a/ImageRegistration/itkJensenTsallisBSplineRegistrationFunction.hxx
+++ b/ImageRegistration/itkJensenTsallisBSplineRegistrationFunction.hxx
@@ -43,7 +43,7 @@ JensenTsallisBSplineRegistrationFunction<TFixedImage,
   this->m_MovingKernelSigma = 0.0;
   this->m_MovingEvaluationKNeighborhood = 50;
 
-  unsigned int covarianceKNeighborhood = static_cast<unsigned int>( vcl_pow( 3.0,
+  unsigned int covarianceKNeighborhood = static_cast<unsigned int>( std::pow( 3.0,
                                                                              static_cast<RealType>( ImageDimension ) ) )
     - 1;
 
@@ -235,7 +235,7 @@ JensenTsallisBSplineRegistrationFunction<TFixedImage,
   for( unsigned int d = 0; d < ImageDimension; d++ )
     {
     numberOfMovingControlPoints[d] = this->m_SplineOrder
-      + static_cast<unsigned int>( vcl_floor( 0.5 + static_cast<RealType>(
+      + static_cast<unsigned int>( std::floor( 0.5 + static_cast<RealType>(
                                                 this->GetMovingImage()->GetLargestPossibleRegion().GetSize()[d] )
                                               / static_cast<RealType>( this->m_MeshResolution[d] ) ) );
     }
@@ -381,7 +381,7 @@ JensenTsallisBSplineRegistrationFunction<TFixedImage,
   for( unsigned int d = 0; d < ImageDimension; d++ )
     {
     numberOfFixedControlPoints[d] = this->m_SplineOrder
-      + static_cast<unsigned int>( vcl_floor( 0.5 + static_cast<RealType>(
+      + static_cast<unsigned int>( std::floor( 0.5 + static_cast<RealType>(
                                                 this->GetFixedImage()->GetLargestPossibleRegion().GetSize()[d] )
                                               / static_cast<RealType>( this->m_MeshResolution[d] ) ) );
     }

--- a/ImageRegistration/itkSyNDemonsRegistrationFunction.cxx
+++ b/ImageRegistration/itkSyNDemonsRegistrationFunction.cxx
@@ -353,7 +353,7 @@ SyNDemonsRegistrationFunction<TFixedImage, TMovingImage, TDisplacementField>
     {
     m_Metric = m_SumOfSquaredDifference
       / static_cast<double>( m_NumberOfPixelsProcessed );
-    m_RMSChange = vcl_sqrt( m_SumOfSquaredChange
+    m_RMSChange = std::sqrt( m_SumOfSquaredChange
                             / static_cast<double>( m_NumberOfPixelsProcessed ) );
     }
 

--- a/ImageSegmentation/antsAtroposSegmentationImageFilter.hxx
+++ b/ImageSegmentation/antsAtroposSegmentationImageFilter.hxx
@@ -1587,11 +1587,11 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
     RealType mrfPriorProbability = 1.0;
     if( mrfSmoothingFactor > 0.0 && ( It.GetNeighborhood() ).Size() > 1 )
       {
-      RealType numerator = vcl_exp( -mrfSmoothingFactor * mrfNeighborhoodWeights[k] );
+      RealType numerator = std::exp( -mrfSmoothingFactor * mrfNeighborhoodWeights[k] );
       RealType denominator = 0.0;
       for( unsigned int n = 0; n < this->m_NumberOfTissueClasses; n++ )
         {
-        denominator += vcl_exp( -mrfSmoothingFactor * mrfNeighborhoodWeights[n] );
+        denominator += std::exp( -mrfSmoothingFactor * mrfNeighborhoodWeights[n] );
         }
       if( denominator > 0.0 )
         {
@@ -1786,9 +1786,9 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
         dev.off()
       */
       posteriorProbability =
-        vcl_pow( static_cast<RealType>( spatialPriorProbability ),
+        std::pow( static_cast<RealType>( spatialPriorProbability ),
                  static_cast<RealType>( this->m_PriorProbabilityWeight ) )
-        * vcl_pow( static_cast<RealType>( likelihood * mrfPriorProbability ),
+        * std::pow( static_cast<RealType>( likelihood * mrfPriorProbability ),
                    static_cast<RealType>( 1.0 - this->m_PriorProbabilityWeight ) );
       }
       break;
@@ -1810,18 +1810,18 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
         mrfPriorProbability = 1.0;
         }
       posteriorProbability =
-        vcl_pow( static_cast<RealType>( spatialPriorProbability ),
+        std::pow( static_cast<RealType>( spatialPriorProbability ),
                  static_cast<RealType>( this->m_PriorProbabilityWeight ) )
-        * vcl_pow( static_cast<RealType>( likelihood * mrfPriorProbability ),
+        * std::pow( static_cast<RealType>( likelihood * mrfPriorProbability ),
                    static_cast<RealType>( 1.0 - this->m_PriorProbabilityWeight ) );
       }
       break;
     case Aristotle:
       {
       posteriorProbability =
-        vcl_pow( static_cast<RealType>( spatialPriorProbability * distancePriorProbability ),
+        std::pow( static_cast<RealType>( spatialPriorProbability * distancePriorProbability ),
                  static_cast<RealType>( this->m_PriorProbabilityWeight ) )
-        * vcl_pow( static_cast<RealType>( likelihood * mrfPriorProbability ),
+        * std::pow( static_cast<RealType>( likelihood * mrfPriorProbability ),
                    static_cast<RealType>( 1.0 - this->m_PriorProbabilityWeight ) );
       }
       break;
@@ -1840,7 +1840,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
       */
       RealType totalNumberOfClasses = static_cast<RealType>( this->m_NumberOfTissueClasses + this->m_NumberOfPartialVolumeClasses );
       RealType offset = 1.0 / totalNumberOfClasses;
-      spatialPriorProbability = 1.0 / ( 1.0 + vcl_exp( -1.0 * ( spatialPriorProbability - offset ) * this->m_PriorProbabilityWeight ) );
+      spatialPriorProbability = 1.0 / ( 1.0 + std::exp( -1.0 * ( spatialPriorProbability - offset ) * this->m_PriorProbabilityWeight ) );
       posteriorProbability = static_cast<RealType>( spatialPriorProbability ) * static_cast<RealType>( likelihood * mrfPriorProbability );
       }
       break;
@@ -1849,12 +1849,12 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
   if( this->m_InitialAnnealingTemperature != 1.0 )
     {
     RealType annealingTemperature = this->m_InitialAnnealingTemperature
-      * vcl_pow( this->m_AnnealingRate, static_cast<RealType>( this->m_ElapsedIterations ) );
+      * std::pow( this->m_AnnealingRate, static_cast<RealType>( this->m_ElapsedIterations ) );
 
     annealingTemperature = vnl_math_max( annealingTemperature,
                                          this->m_MinimumAnnealingTemperature );
 
-    posteriorProbability = vcl_pow( static_cast<RealType>( posteriorProbability ),
+    posteriorProbability = std::pow( static_cast<RealType>( posteriorProbability ),
                                     static_cast<RealType>( 1.0 / annealingTemperature ) );
     }
   if( vnl_math_isnan( posteriorProbability ) ||
@@ -1910,7 +1910,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
           {
           distance += vnl_math_sqr( offset[d] * this->m_ImageSpacing[d] );
           }
-        distance = vcl_sqrt( distance );
+        distance = std::sqrt( distance );
 
         RealType delta = 0.0;
         if( label == neighborLabel )
@@ -2109,12 +2109,12 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
               Array<RealType> mrfNeighborhoodWeights;
               this->EvaluateMRFNeighborhoodWeights( ItO, mrfNeighborhoodWeights );
 
-              RealType numerator = vcl_exp( -mrfSmoothingFactor
+              RealType numerator = std::exp( -mrfSmoothingFactor
                                             * mrfNeighborhoodWeights[c] );
               RealType denominator = 0.0;
               for( unsigned int n = 0; n < totalNumberOfClasses; n++ )
                 {
-                denominator += vcl_exp( -mrfSmoothingFactor
+                denominator += std::exp( -mrfSmoothingFactor
                                         * mrfNeighborhoodWeights[n] );
                 }
               if( denominator > 0.0 )
@@ -2370,12 +2370,12 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
             Array<RealType> mrfNeighborhoodWeights;
             this->EvaluateMRFNeighborhoodWeights( ItO, mrfNeighborhoodWeights );
 
-            RealType numerator = vcl_exp( -mrfSmoothingFactor
+            RealType numerator = std::exp( -mrfSmoothingFactor
                                           * mrfNeighborhoodWeights[whichClass - 1] );
             RealType denominator = 0.0;
             for( unsigned int n = 0; n < totalNumberOfClasses; n++ )
               {
-              denominator += vcl_exp( -mrfSmoothingFactor * mrfNeighborhoodWeights[n] );
+              denominator += std::exp( -mrfSmoothingFactor * mrfNeighborhoodWeights[n] );
               }
             if( denominator > 0.0 )
               {
@@ -2690,7 +2690,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
           else if( ItD.Get() >= 0 )
             {
             ItD.Set( labelBoundaryProbability
-                     * vcl_exp( -labelLambda * ItD.Get() ) );
+                     * std::exp( -labelLambda * ItD.Get() ) );
             }
           else if( ItD.Get() < 0 )
             {
@@ -2920,7 +2920,7 @@ AtroposSegmentationImageFilter<TInputImage, TMaskImage, TClassifiedImage>
         else if( ItD.Get() >= 0 )
           {
           ItD.Set( labelBoundaryProbability
-                   * vcl_exp( -labelLambda * ItD.Get() ) );
+                   * std::exp( -labelLambda * ItD.Get() ) );
           }
         else if( ItD.Get() < 0 )
           {

--- a/ImageSegmentation/antsGrubbsRosnerListSampleFilter.hxx
+++ b/ImageSegmentation/antsGrubbsRosnerListSampleFilter.hxx
@@ -143,8 +143,8 @@ GrubbsRosnerListSampleFilter<TScalarListSample>
         1.0 - 0.5 * this->m_WinsorizingLevel,
         this->GetInput()->Size() - this->m_OutlierInstanceIdentifiers.size() );
 
-    lowerWinsorBound = mean - t * vcl_sqrt( variance );
-    upperWinsorBound = mean + t * vcl_sqrt( variance );
+    lowerWinsorBound = mean - t * std::sqrt( variance );
+    upperWinsorBound = mean + t * std::sqrt( variance );
     }
 
   It = this->GetInput()->Begin();
@@ -231,9 +231,9 @@ GrubbsRosnerListSampleFilter<TScalarListSample>
   RealType t = tdistribution->EvaluateInverseCDF( 1.0 - sig, N - 2 );
 
   RealType nu = static_cast<RealType>( N - 1 );
-  RealType g = nu / vcl_sqrt( nu + 1.0 ) * vcl_sqrt( t * t / ( nu - 1 + t * t ) );
+  RealType g = nu / std::sqrt( nu + 1.0 ) * std::sqrt( t * t / ( nu - 1 + t * t ) );
 
-  return g < ( vnl_math_abs( x - mean ) / vcl_sqrt( variance ) );
+  return g < ( vnl_math_abs( x - mean ) / std::sqrt( variance ) );
 }
 
 template <class TScalarListSample>

--- a/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.hxx
+++ b/ImageSegmentation/antsHistogramParzenWindowsListSampleFunction.hxx
@@ -111,7 +111,7 @@ HistogramParzenWindowsListSampleFunction<TListSample, TOutput, TCoordRep>
 
     typename HistogramImageType::SizeType size;
     size[0] = static_cast<unsigned int>(
-        vcl_ceil( ( maxValues[d] + 3.0 * ( this->m_Sigma * spacing[0] )
+        std::ceil( ( maxValues[d] + 3.0 * ( this->m_Sigma * spacing[0] )
                     - ( minValues[d] - 3.0 * ( this->m_Sigma * spacing[0] ) ) ) / spacing[0] ) );
 
     this->m_HistogramImages[d]->SetOrigin( origin );
@@ -144,7 +144,7 @@ HistogramParzenWindowsListSampleFunction<TListSample, TOutput, TCoordRep>
       typename HistogramImageType::IndexType idx;
 
       idx[0] = static_cast<typename
-                           HistogramImageType::IndexType::IndexValueType>( vcl_floor( cidx[0] ) );
+                           HistogramImageType::IndexType::IndexValueType>( std::floor( cidx[0] ) );
       if( this->m_HistogramImages[d]->GetLargestPossibleRegion().IsInside( idx ) )
         {
         RealType oldWeight = this->m_HistogramImages[d]->GetPixel( idx );

--- a/ImageSegmentation/antsJointHistogramParzenShapeAndOrientationListSampleFunction.hxx
+++ b/ImageSegmentation/antsJointHistogramParzenShapeAndOrientationListSampleFunction.hxx
@@ -111,8 +111,8 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
   /** Nearest neighbor increment to JH */
   if( this->m_UseNearestNeighborIncrements )
     {
-    shapeIdx[0] = static_cast<typename JointHistogramImageIndexType::IndexValueType>( vcl_floor( shapeCidx[0] + 0.5 ) );
-    shapeIdx[1] = static_cast<typename JointHistogramImageIndexType::IndexValueType>( vcl_floor( shapeCidx[1] + 0.5 ) );
+    shapeIdx[0] = static_cast<typename JointHistogramImageIndexType::IndexValueType>( std::floor( shapeCidx[0] + 0.5 ) );
+    shapeIdx[1] = static_cast<typename JointHistogramImageIndexType::IndexValueType>( std::floor( shapeCidx[1] + 0.5 ) );
     if( this->m_JointHistogramImages[0]->
         GetLargestPossibleRegion().IsInside( shapeIdx ) )
       {
@@ -123,18 +123,18 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
   else
     {
     /** linear addition */
-    shapeIdx[0] = static_cast<IndexValueType>( vcl_floor( shapeCidx[0] ) );
-    shapeIdx[1] = static_cast<IndexValueType>( vcl_floor( shapeCidx[1] ) );
-    RealType distance1 = vcl_sqrt( vnl_math_sqr( shapeCidx[0] - shapeIdx[0] )
+    shapeIdx[0] = static_cast<IndexValueType>( std::floor( shapeCidx[0] ) );
+    shapeIdx[1] = static_cast<IndexValueType>( std::floor( shapeCidx[1] ) );
+    RealType distance1 = std::sqrt( vnl_math_sqr( shapeCidx[0] - shapeIdx[0] )
                                    + vnl_math_sqr( shapeCidx[1] - shapeIdx[1] ) );
     shapeIdx[0]++;
-    RealType distance2 = vcl_sqrt( vnl_math_sqr( shapeCidx[0] - shapeIdx[0] )
+    RealType distance2 = std::sqrt( vnl_math_sqr( shapeCidx[0] - shapeIdx[0] )
                                    + vnl_math_sqr( shapeCidx[1] - shapeIdx[1] ) );
     shapeIdx[1]++;
-    RealType distance3 = vcl_sqrt( vnl_math_sqr( shapeCidx[0] - shapeIdx[0] )
+    RealType distance3 = std::sqrt( vnl_math_sqr( shapeCidx[0] - shapeIdx[0] )
                                    + vnl_math_sqr( shapeCidx[1] - shapeIdx[1] ) );
     shapeIdx[0]--;
-    RealType distance4 = vcl_sqrt( vnl_math_sqr( shapeCidx[0] - shapeIdx[0] )
+    RealType distance4 = std::sqrt( vnl_math_sqr( shapeCidx[0] - shapeIdx[0] )
                                    + vnl_math_sqr( shapeCidx[1] - shapeIdx[1] ) );
     RealType sumDistance = distance1 + distance2 + distance3 + distance4;
     distance1 /= sumDistance;
@@ -143,8 +143,8 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
     distance4 /= sumDistance;
 
     unsigned int whichHistogram = 0;
-    shapeIdx[0] = static_cast<IndexValueType>( vcl_floor( shapeCidx[0] ) );
-    shapeIdx[1] = static_cast<IndexValueType>( vcl_floor( shapeCidx[1] ) );
+    shapeIdx[0] = static_cast<IndexValueType>( std::floor( shapeCidx[0] ) );
+    shapeIdx[1] = static_cast<IndexValueType>( std::floor( shapeCidx[1] ) );
     if( this->m_JointHistogramImages[whichHistogram]->
         GetLargestPossibleRegion().IsInside( shapeIdx ) )
       {
@@ -226,7 +226,7 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
     z *= -1;
     }
 
-  tp[0] = vcl_acos( z );
+  tp[0] = std::acos( z );
 
   // phi goes from 0.0 (+x axis) and goes to -pi/2 and pi/2.
   // theta goes from 0.0 (+z axis) and wraps at PI
@@ -264,11 +264,11 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
       }
     else if( x > 0.0 && y > 0.0 )
       {     // first quadrant
-      tp[1] = vcl_atan( y / x );
+      tp[1] = std::atan( y / x );
       }
     else if( x < 0.0 && y > 0.0 )
       {     // second quadrant
-      tp[1] = vnl_math::pi + vcl_atan( y / x );
+      tp[1] = vnl_math::pi + std::atan( y / x );
       }
     else if( x < 0.0 && y < 0.0 )
       {     // third quadrant
@@ -300,9 +300,9 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
   if( this->m_UseNearestNeighborIncrements )
     {
     orientIdx[0] =
-      static_cast<typename JointHistogramImageIndexType::IndexValueType>( vcl_floor( orientCidx[0] + 0.5 ) );
+      static_cast<typename JointHistogramImageIndexType::IndexValueType>( std::floor( orientCidx[0] + 0.5 ) );
     orientIdx[1] =
-      static_cast<typename JointHistogramImageIndexType::IndexValueType>( vcl_floor( orientCidx[1] + 0.5 ) );
+      static_cast<typename JointHistogramImageIndexType::IndexValueType>( std::floor( orientCidx[1] + 0.5 ) );
     if( this->m_JointHistogramImages[whichHistogram]->
         GetLargestPossibleRegion().IsInside( orientIdx ) )
       {
@@ -314,18 +314,18 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
     }
   else
     {
-    orientIdx[0] = static_cast<IndexValueType>( vcl_floor( orientCidx[0] ) );
-    orientIdx[1] = static_cast<IndexValueType>( vcl_floor( orientCidx[1] ) );
-    RealType distance1 = vcl_sqrt( vnl_math_sqr( orientCidx[0] - orientIdx[0] )
+    orientIdx[0] = static_cast<IndexValueType>( std::floor( orientCidx[0] ) );
+    orientIdx[1] = static_cast<IndexValueType>( std::floor( orientCidx[1] ) );
+    RealType distance1 = std::sqrt( vnl_math_sqr( orientCidx[0] - orientIdx[0] )
                                    + vnl_math_sqr( orientCidx[1] - orientIdx[1] ) );
     orientIdx[0]++;
-    RealType distance2 = vcl_sqrt( vnl_math_sqr( orientCidx[0] - orientIdx[0] )
+    RealType distance2 = std::sqrt( vnl_math_sqr( orientCidx[0] - orientIdx[0] )
                                    + vnl_math_sqr( orientCidx[1] - orientIdx[1] ) );
     orientIdx[1]++;
-    RealType distance3 = vcl_sqrt( vnl_math_sqr( orientCidx[0] - orientIdx[0] )
+    RealType distance3 = std::sqrt( vnl_math_sqr( orientCidx[0] - orientIdx[0] )
                                    + vnl_math_sqr( orientCidx[1] - orientIdx[1] ) );
     orientIdx[0]--;
-    RealType distance4 = vcl_sqrt( vnl_math_sqr( orientCidx[0] - orientIdx[0] )
+    RealType distance4 = std::sqrt( vnl_math_sqr( orientCidx[0] - orientIdx[0] )
                                    + vnl_math_sqr( orientCidx[1] - orientIdx[1] ) );
     RealType sumDistance = distance1 + distance2 + distance3 + distance4;
     distance1 /= sumDistance;
@@ -333,8 +333,8 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
     distance3 /= sumDistance;
     distance4 /= sumDistance;
 
-    orientIdx[0] = static_cast<IndexValueType>( vcl_floor( orientCidx[0] ) );
-    orientIdx[1] = static_cast<IndexValueType>( vcl_floor( orientCidx[1] ) );
+    orientIdx[0] = static_cast<IndexValueType>( std::floor( orientCidx[0] ) );
+    orientIdx[1] = static_cast<IndexValueType>( std::floor( orientCidx[1] ) );
     if( this->m_JointHistogramImages[whichHistogram]->
         GetLargestPossibleRegion().IsInside( orientIdx ) )
       {
@@ -457,7 +457,7 @@ JointHistogramParzenShapeAndOrientationListSampleFunction<TListSample, TOutput, 
 
   RealType L = static_cast<RealType>(
       this->GetInputListSample()->GetMeasurementVectorSize() );
-  unsigned int D = static_cast<unsigned int>( 0.5 * ( -1 + vcl_sqrt( 1.0
+  unsigned int D = static_cast<unsigned int>( 0.5 * ( -1 + std::sqrt( 1.0
                                                                      + 8.0 * L ) ) );
 
   It = this->GetInputListSample()->Begin();

--- a/ImageSegmentation/antsJointHistogramParzenWindowsListSampleFunction.hxx
+++ b/ImageSegmentation/antsJointHistogramParzenWindowsListSampleFunction.hxx
@@ -99,8 +99,8 @@ JointHistogramParzenWindowsListSampleFunction<TListSample, TOutput, TCoordRep>
 /** Nearest neighbor increment to JH */
   if( this->m_UseNNforJointHistIncrements )
     {
-    shapeIdx[0] = vcl_floor( shapeCidx[0] + 0.5);
-    shapeIdx[1] = vcl_floor( shapeCidx[1] + 0.5 );
+    shapeIdx[0] = std::floor( shapeCidx[0] + 0.5);
+    shapeIdx[1] = std::floor( shapeCidx[1] + 0.5 );
     if( this->m_JointHistogramImages[which_hist]->GetLargestPossibleRegion().IsInside( shapeIdx ) )
       {
       RealType oldWeight = this->m_JointHistogramImages[which_hist]->GetPixel( shapeIdx );
@@ -111,9 +111,9 @@ JointHistogramParzenWindowsListSampleFunction<TListSample, TOutput, TCoordRep>
     {
 /** linear addition */
     shapeIdx[0] = static_cast<typename
-                              JointHistogramImageType::IndexType::IndexValueType>( vcl_floor( shapeCidx[0] ) );
+                              JointHistogramImageType::IndexType::IndexValueType>( std::floor( shapeCidx[0] ) );
     shapeIdx[1] = static_cast<typename
-                              JointHistogramImageType::IndexType::IndexValueType>( vcl_floor( shapeCidx[1] ) );
+                              JointHistogramImageType::IndexType::IndexValueType>( std::floor( shapeCidx[1] ) );
     RealType dist1 =
       sqrt( (shapeCidx[0]
              - shapeIdx[0])
@@ -140,9 +140,9 @@ JointHistogramParzenWindowsListSampleFunction<TListSample, TOutput, TCoordRep>
     dist4 /= distsum;
 
     shapeIdx[0] = static_cast<typename
-                              JointHistogramImageType::IndexType::IndexValueType>( vcl_floor( shapeCidx[0] ) );
+                              JointHistogramImageType::IndexType::IndexValueType>( std::floor( shapeCidx[0] ) );
     shapeIdx[1] = static_cast<typename
-                              JointHistogramImageType::IndexType::IndexValueType>( vcl_floor( shapeCidx[1] ) );
+                              JointHistogramImageType::IndexType::IndexValueType>( std::floor( shapeCidx[1] ) );
     if( this->m_JointHistogramImages[which_hist]->GetLargestPossibleRegion().IsInside( shapeIdx ) )
       {
       RealType oldWeight = this->m_JointHistogramImages[which_hist]->GetPixel( shapeIdx );

--- a/ImageSegmentation/antsLogEuclideanGaussianListSampleFunction.hxx
+++ b/ImageSegmentation/antsLogEuclideanGaussianListSampleFunction.hxx
@@ -55,7 +55,7 @@ LogEuclideanGaussianListSampleFunction<TListSample, TOutput, TCoordRep>
     {
     RealType L = static_cast<RealType>(
         this->GetInputListSample()->GetMeasurementVectorSize() );
-    unsigned int D = static_cast<unsigned int>( 0.5 * ( -1 + vcl_sqrt( 1.0
+    unsigned int D = static_cast<unsigned int>( 0.5 * ( -1 + std::sqrt( 1.0
                                                                        + 8.0 * L ) ) );
     this->m_MeanTensor.SetSize( D, D );
     this->m_MeanTensor.Fill( 0.0 );
@@ -160,7 +160,7 @@ LogEuclideanGaussianListSampleFunction<TListSample, TOutput, TCoordRep>
     {
     if( W( i, i ) > 0.0 )
       {
-      W( i, i ) = vcl_log( W( i, i ) );
+      W( i, i ) = std::log( W( i, i ) );
       }
     else
       {
@@ -188,7 +188,7 @@ LogEuclideanGaussianListSampleFunction<TListSample, TOutput, TCoordRep>
   decomposer->EvaluateSymmetricEigenDecomposition( Tc, W, V );
   for( unsigned int i = 0; i < W.Rows(); i++ )
     {
-    W( i, i ) = vcl_exp( W( i, i ) );
+    W( i, i ) = std::exp( W( i, i ) );
     }
   W *= V.GetTranspose();
   TensorType expT = V * W;
@@ -206,7 +206,7 @@ LogEuclideanGaussianListSampleFunction<TListSample, TOutput, TCoordRep>
 
   TensorType diff = logS - logT;
   TensorType diffSq = diff * diff;
-  RealType   distance = vcl_sqrt( vnl_trace( ( diffSq ).GetVnlMatrix() ) );
+  RealType   distance = std::sqrt( vnl_trace( ( diffSq ).GetVnlMatrix() ) );
 
 //  RealType distance = ( ( logS - logT ).GetVnlMatrix() ).frobenius_norm();
   return distance;
@@ -233,8 +233,8 @@ LogEuclideanGaussianListSampleFunction<TListSample, TOutput, TCoordRep>
     }
   RealType distance = this->CalculateTensorDistance( T, this->m_MeanTensor );
   RealType preFactor = 1.0
-    / ( vcl_sqrt( 2.0 * vnl_math::pi * this->m_Dispersion ) );
-  RealType probability = preFactor * vcl_exp( -0.5
+    / ( std::sqrt( 2.0 * vnl_math::pi * this->m_Dispersion ) );
+  RealType probability = preFactor * std::exp( -0.5
                                               * vnl_math_sqr( distance ) / this->m_Dispersion );
 
   return probability;

--- a/Temporary/antsFastMarchingImageFilter.hxx
+++ b/Temporary/antsFastMarchingImageFilter.hxx
@@ -644,7 +644,7 @@ FMarchingImageFilter<TLevelSet, TSpeedImage>
         throw err;
         }
 
-      solution = ( vcl_sqrt( discrim ) + bb ) / aa;
+      solution = ( std::sqrt( discrim ) + bb ) / aa;
       }
     else
       {

--- a/Temporary/itkFEMConformalMap.cxx
+++ b/Temporary/itkFEMConformalMap.cxx
@@ -20,8 +20,10 @@
 #include "vtkCleanPolyData.h"
 #include "vtkPolyDataConnectivityFilter.h"
 
-#include <vcl_cmath.h>
-#include <vcl_iostream.h>
+#include <vcl_compiler.h>
+#include <iostream>
+#include <cmath>
+#include <iostream>
 #include <vnl/vnl_real_polynomial.h>
 #include <vnl/vnl_vector.h>
 #include <vnl/vnl_vector_fixed.h>

--- a/Temporary/itkFEMDiscConformalMap.cxx
+++ b/Temporary/itkFEMDiscConformalMap.cxx
@@ -13,8 +13,10 @@
 #ifndef _FEMDiscConformalMap_hxx
 #define _FEMDiscConformalMap_hxx
 
-#include <vcl_cmath.h>
-#include <vcl_iostream.h>
+#include <vcl_compiler.h>
+#include <iostream>
+#include <cmath>
+#include <iostream>
 #include <vnl/vnl_real_polynomial.h>
 #include <vnl/vnl_vector.h>
 #include <vnl/vnl_vector_fixed.h>

--- a/Tensor/TensorFunctions.h
+++ b/Tensor/TensorFunctions.h
@@ -625,9 +625,9 @@ itk::RGBPixel<unsigned char>   GetTensorRGB( TTensorType dtv )
   EigenAnalysis<TensorType, EigenMatrixType>(dtv, evals, evecs);
   float fa = GetTensorFA<TensorType>(dtv);
 
-  rgb[0] = (unsigned char)(vcl_fabs(evecs(0, 2) ) * fa * 255);
-  rgb[1] = (unsigned char)(vcl_fabs(evecs(1, 2) ) * fa * 255);
-  rgb[2] = (unsigned char)(vcl_fabs(evecs(2, 2) ) * fa * 255);
+  rgb[0] = (unsigned char)(std::fabs(evecs(0, 2) ) * fa * 255);
+  rgb[1] = (unsigned char)(std::fabs(evecs(1, 2) ) * fa * 255);
+  rgb[2] = (unsigned char)(std::fabs(evecs(2, 2) ) * fa * 255);
 
   return rgb;
 }
@@ -690,7 +690,7 @@ itk::RGBPixel<float>   GetTensorPrincipalEigenvector( TTensorType dtv )
     trace += dtv[3];
     trace += dtv[5];
     float anisotropy = 3.0 * isp - trace * trace;
-    fa = ( vcl_sqrt(anisotropy / ( 2.0 * isp ) ) );
+    fa = ( std::sqrt(anisotropy / ( 2.0 * isp ) ) );
     }
 
   // rgb[0]=eig.V(2,0)*fa*255;//+eig.V(1,0)*e2;

--- a/Tensor/itkDecomposeTensorFunction2.hxx
+++ b/Tensor/itkDecomposeTensorFunction2.hxx
@@ -62,7 +62,7 @@ DecomposeTensorFunction2<TInput, TRealType, TOutput>
       V[i][j] = static_cast<RealType>( (eig.Vreal).get( i, j ) );
       if( i == j )
         {
-        D[i][j] = static_cast<RealType>( vcl_real( eig.D(j) ) );
+        D[i][j] = static_cast<RealType>( std::real( eig.D(j) ) );
         }
       }
     }

--- a/Tensor/itkWarpTensorImageMultiTransformFilter.hxx
+++ b/Tensor/itkWarpTensorImageMultiTransformFilter.hxx
@@ -82,11 +82,11 @@ TTensorType LogExpTensor( TTensorType inTensor, bool doLog )
       {
       if( doLog )
         {
-        eSystem.D[i] = vcl_log(vcl_fabs(eSystem.D[i]) );
+        eSystem.D[i] = std::log(std::fabs(eSystem.D[i]) );
         }
       else
         {
-        eSystem.D[i] = vcl_exp(eSystem.D[i]);
+        eSystem.D[i] = std::exp(eSystem.D[i]);
         }
       }
 

--- a/Utilities/antsSCCANObject.hxx
+++ b/Utilities/antsSCCANObject.hxx
@@ -691,8 +691,8 @@ antsSCCANObject<TInputImage, TRealType>
     typename FilterType::Pointer filter = FilterType::New();
     filter->SetInput( image );
     filter->SetNumberOfIterations( vnl_math_abs( this->m_Smoother ) );
-    TRealType mytimestep = spacingsize / vcl_pow( 2.0 , static_cast<double>(ImageDimension+1) );
-    TRealType reftimestep = 0.5 / vcl_pow( 2.0 , static_cast<double>(ImageDimension+1) );
+    TRealType mytimestep = spacingsize / std::pow( 2.0 , static_cast<double>(ImageDimension+1) );
+    TRealType reftimestep = 0.5 / std::pow( 2.0 , static_cast<double>(ImageDimension+1) );
     if ( mytimestep > reftimestep ) mytimestep = reftimestep;
     filter->SetTimeStep( mytimestep );
     filter->SetConductanceParameter( 0.25 ); // might need to change this

--- a/Utilities/itkDecomposeTensorFunction.hxx
+++ b/Utilities/itkDecomposeTensorFunction.hxx
@@ -63,7 +63,7 @@ DecomposeTensorFunction<TInput, TRealType, TOutput>
       V[i][j] = static_cast<RealType>( (eig.Vreal).get( i, j ) );
       if( i == j )
         {
-        D[i][j] = static_cast<RealType>( vcl_real( eig.D(j) ) );
+        D[i][j] = static_cast<RealType>( std::real( eig.D(j) ) );
         }
       }
     }

--- a/Utilities/itkDiReCTImageFilter.hxx
+++ b/Utilities/itkDiReCTImageFilter.hxx
@@ -881,7 +881,7 @@ DiReCTImageFilter<TInputImage, TOutputImage>
     {
     RealType domain = static_cast<RealType>(
       inputField->GetLargestPossibleRegion().GetSize()[d] - 1 ) * inputField->GetSpacing()[d];
-    ncps[d] = static_cast<unsigned int>( vcl_ceil( domain / isotropicMeshSpacing ) );
+    ncps[d] = static_cast<unsigned int>( std::ceil( domain / isotropicMeshSpacing ) );
     }
 
   typename BSplineFilterType::Pointer bspliner = BSplineFilterType::New();

--- a/Utilities/itkGeometricJacobianDeterminantImageFilter.hxx
+++ b/Utilities/itkGeometricJacobianDeterminantImageFilter.hxx
@@ -158,7 +158,7 @@ GeometricJacobianDeterminantImageFilter<TInputImage, TRealType, TOutputImage>
 
   cidx[0] = 0.5;
   cidx[1] = 0.0;
-  cidx[2] = -0.5 / vcl_sqrt( 2.0 );
+  cidx[2] = -0.5 / std::sqrt( 2.0 );
 
   this->m_RealValuedInputImage->TransformContinuousIndexToPhysicalPoint( cidx, deltaPoint );
 
@@ -166,7 +166,7 @@ GeometricJacobianDeterminantImageFilter<TInputImage, TRealType, TOutputImage>
 
   cidx[0] = -0.5;
   cidx[1] = 0.0;
-  cidx[2] = -0.5 / vcl_sqrt( 2.0 );
+  cidx[2] = -0.5 / std::sqrt( 2.0 );
 
   this->m_RealValuedInputImage->TransformContinuousIndexToPhysicalPoint( cidx, deltaPoint );
 
@@ -174,7 +174,7 @@ GeometricJacobianDeterminantImageFilter<TInputImage, TRealType, TOutputImage>
 
   cidx[0] = 0.0;
   cidx[1] = 0.5;
-  cidx[2] = 0.5 / vcl_sqrt( 2.0 );
+  cidx[2] = 0.5 / std::sqrt( 2.0 );
 
   this->m_RealValuedInputImage->TransformContinuousIndexToPhysicalPoint( cidx, deltaPoint );
 
@@ -182,7 +182,7 @@ GeometricJacobianDeterminantImageFilter<TInputImage, TRealType, TOutputImage>
 
   cidx[0] = 0.0;
   cidx[1] = -0.5;
-  cidx[2] = 0.5 / vcl_sqrt( 2.0 );
+  cidx[2] = 0.5 / std::sqrt( 2.0 );
 
   this->m_RealValuedInputImage->TransformContinuousIndexToPhysicalPoint( cidx, deltaPoint );
 
@@ -204,21 +204,21 @@ GeometricJacobianDeterminantImageFilter<TInputImage, TRealType, TOutputImage>
   typename InputImageType::PointType deltaPoint;
 
   cidx[0] = 0.0;
-  cidx[1] = 0.25 * vcl_sqrt( 3.0 );
+  cidx[1] = 0.25 * std::sqrt( 3.0 );
 
   this->m_RealValuedInputImage->TransformContinuousIndexToPhysicalPoint( cidx, deltaPoint );
 
   this->m_DeltaTriangularPointA = deltaPoint - originPoint;
 
   cidx[0] = -0.5;
-  cidx[1] = -0.25 * vcl_sqrt( 3.0 );
+  cidx[1] = -0.25 * std::sqrt( 3.0 );
 
   this->m_RealValuedInputImage->TransformContinuousIndexToPhysicalPoint( cidx, deltaPoint );
 
   this->m_DeltaTriangularPointB = deltaPoint - originPoint;
 
   cidx[0] = 0.5;
-  cidx[1] = -0.25 * vcl_sqrt( 3.0 );
+  cidx[1] = -0.25 * std::sqrt( 3.0 );
 
   this->m_RealValuedInputImage->TransformContinuousIndexToPhysicalPoint( cidx, deltaPoint );
 

--- a/Utilities/itkLabelPerimeterEstimationCalculator.hxx
+++ b/Utilities/itkLabelPerimeterEstimationCalculator.hxx
@@ -145,9 +145,9 @@ LabelPerimeterEstimationCalculator< TInputImage >
   typedef typename std::map< unsigned long, double > ContributionMapType;
   ContributionMapType contributions;
   const unsigned int  numberOfNeighbors      =
-    static_cast< unsigned int >( vcl_pow( 2.0, static_cast< double >( ImageDimension ) ) );
+    static_cast< unsigned int >( std::pow( 2.0, static_cast< double >( ImageDimension ) ) );
   const unsigned int numberOfConfigurations =
-    static_cast< unsigned int >( vcl_pow( 2.0, static_cast< double >( numberOfNeighbors ) ) );
+    static_cast< unsigned int >( std::pow( 2.0, static_cast< double >( numberOfNeighbors ) ) );
   // create an image to store the neighbors
   typedef typename itk::Image< bool, ImageDimension > ImageType;
   typename ImageType::Pointer neighborsImage = ImageType::New();
@@ -176,7 +176,7 @@ LabelPerimeterEstimationCalculator< TInputImage >
         for ( unsigned int k = 0; k < ImageDimension; k++ )
           {
           IndexType idx = currentIdx;
-          idx[k] = vcl_abs(idx[k] - 1);
+          idx[k] = std::abs(idx[k] - 1);
           if ( !neighborsImage->GetPixel(idx) )
             {
             contributions[i] += physicalSize / this->GetImage()->GetSpacing()[k] / 2.0;

--- a/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
+++ b/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.h
@@ -73,7 +73,7 @@ public:
   /** The sigma of the laplacian where the extrema occoured */
   double GetScaleSpaceSigma( void ) const
   {
-    return this->GetSigma() / ( vcl_sqrt( TDimension / 2.0 ) );
+    return this->GetSigma() / ( std::sqrt( TDimension / 2.0 ) );
   }
 
   /** The location where the extrema occoured */

--- a/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.hxx
+++ b/Utilities/itkMultiScaleLaplacianBlobDetectorImageFilter.hxx
@@ -82,10 +82,10 @@ void MultiScaleLaplacianBlobDetectorImageFilter<TInputImage>
 
   // we wish to add an additional laplacian before and after the user
   // defined range to check for maximums
-  const double k = vcl_pow( 2.0, 1.0 / m_StepsPerOctave );
-  const double initial_sigma = vcl_sqrt(m_StartT) * 1.0 / k;
+  const double k = std::pow( 2.0, 1.0 / m_StepsPerOctave );
+  const double initial_sigma = std::sqrt(m_StartT) * 1.0 / k;
 
-  const unsigned int numberOfScales = vcl_ceil( vcl_log( vcl_sqrt( m_EndT ) / initial_sigma ) / vcl_log( k ) ) + 1.0;
+  const unsigned int numberOfScales = std::ceil( std::log( std::sqrt( m_EndT ) / initial_sigma ) / std::log( k ) ) + 1.0;
 
   typedef itk::LaplacianRecursiveGaussianImageFilter<InputImageType, RealImageType> LaplacianFilterType;
   typename LaplacianFilterType::Pointer laplacianFilter[3];
@@ -104,8 +104,8 @@ void MultiScaleLaplacianBlobDetectorImageFilter<TInputImage>
     {
     // simga' = k^i * initial_sigma
     // t = sigma^2
-    const double sigma = initial_sigma * vcl_pow( k, double( numberOfScales - i - 1 ) );
-    //    const double t = vnl_math_sqr( initial_sigma * vcl_pow( k, double( numberOfScales - i - 1 ) ) );
+    const double sigma = initial_sigma * std::pow( k, double( numberOfScales - i - 1 ) );
+    //    const double t = vnl_math_sqr( initial_sigma * std::pow( k, double( numberOfScales - i - 1 ) ) );
 
     itkDebugMacro( << "i: " << i << " sigma: " << sigma << " k: " << k );
 
@@ -192,7 +192,7 @@ void MultiScaleLaplacianBlobDetectorImageFilter<TInputImage>
   // Convert to SpatialObject blob
   for( typename BlobHeapType::const_iterator i = blobs.begin(); i != blobs.end(); ++i )
     {
-    const double sigma =  vcl_sqrt( InputImageType::ImageDimension / 2.0 ) * i->m_Sigma;
+    const double sigma =  std::sqrt( InputImageType::ImageDimension / 2.0 ) * i->m_Sigma;
 
     // transform the center index into offset vector
     typename BlobType::PointType centerPoint;

--- a/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.hxx
+++ b/Utilities/itkN3MRIBiasFieldCorrectionImageFilter.hxx
@@ -383,15 +383,15 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
    * histogram to a power of 2.
    */
 
-  RealType exponent = vcl_ceil( vcl_log( static_cast<RealType>(
-                                           this->m_NumberOfHistogramBins ) ) / vcl_log( 2.0 ) ) + 1;
+  RealType exponent = std::ceil( std::log( static_cast<RealType>(
+                                           this->m_NumberOfHistogramBins ) ) / std::log( 2.0 ) ) + 1;
   unsigned int paddedHistogramSize = static_cast<unsigned int>(
-      vcl_pow( static_cast<RealType>( 2.0 ), exponent ) + 0.5 );
+      std::pow( static_cast<RealType>( 2.0 ), exponent ) + 0.5 );
   unsigned int histogramOffset = static_cast<unsigned int>( 0.5
                                                             * ( paddedHistogramSize - this->m_NumberOfHistogramBins ) );
 
-  vnl_vector<vcl_complex<RealType> > V( paddedHistogramSize,
-                                        vcl_complex<RealType>( 0.0, 0.0 ) );
+  vnl_vector<std::complex<RealType> > V( paddedHistogramSize,
+                                        std::complex<RealType>( 0.0, 0.0 ) );
   for( unsigned int n = 0; n < this->m_NumberOfHistogramBins; n++ )
     {
     V[n + histogramOffset] = H[n];
@@ -402,71 +402,71 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
    */
   vnl_fft_1d<RealType> fft( paddedHistogramSize );
 
-  vnl_vector<vcl_complex<RealType> > Vf( V );
+  vnl_vector<std::complex<RealType> > Vf( V );
   fft.fwd_transform( Vf );
 
   /**
    * Create the Gaussian filter.
    */
   RealType scaledFWHM = this->m_BiasFieldFullWidthAtHalfMaximum / histogramSlope;
-  RealType expFactor = 4.0 * vcl_log( 2.0 ) / vnl_math_sqr( scaledFWHM );
-  RealType scaleFactor = 2.0 * vcl_sqrt( vcl_log( 2.0 )
+  RealType expFactor = 4.0 * std::log( 2.0 ) / vnl_math_sqr( scaledFWHM );
+  RealType scaleFactor = 2.0 * std::sqrt( std::log( 2.0 )
                                          / vnl_math::pi ) / scaledFWHM;
 
-  vnl_vector<vcl_complex<RealType> > F( paddedHistogramSize,
-                                        vcl_complex<RealType>( 0.0, 0.0 ) );
-  F[0] = vcl_complex<RealType>( scaleFactor, 0.0 );
+  vnl_vector<std::complex<RealType> > F( paddedHistogramSize,
+                                        std::complex<RealType>( 0.0, 0.0 ) );
+  F[0] = std::complex<RealType>( scaleFactor, 0.0 );
   unsigned int halfSize = static_cast<unsigned int>(
       0.5 * paddedHistogramSize );
   for( unsigned int n = 1; n <= halfSize; n++ )
     {
-    F[n] = F[paddedHistogramSize - n] = vcl_complex<RealType>(
-          scaleFactor * vcl_exp( -vnl_math_sqr( static_cast<RealType>( n ) )
+    F[n] = F[paddedHistogramSize - n] = std::complex<RealType>(
+          scaleFactor * std::exp( -vnl_math_sqr( static_cast<RealType>( n ) )
                                  * expFactor ), 0.0 );
     }
   if( paddedHistogramSize % 2 == 0 )
     {
-    F[halfSize] = vcl_complex<RealType>( scaleFactor * vcl_exp( 0.25
+    F[halfSize] = std::complex<RealType>( scaleFactor * std::exp( 0.25
                                                                 * -vnl_math_sqr( static_cast<RealType>(
                                                                                    paddedHistogramSize ) )
                                                                 * expFactor ), 0.0 );
     }
 
-  vnl_vector<vcl_complex<RealType> > Ff( F );
+  vnl_vector<std::complex<RealType> > Ff( F );
   fft.fwd_transform( Ff );
 
   /**
    * Create the Weiner deconvolution filter.
    */
-  vnl_vector<vcl_complex<RealType> > Gf( paddedHistogramSize );
+  vnl_vector<std::complex<RealType> > Gf( paddedHistogramSize );
   for( unsigned int n = 0; n < paddedHistogramSize; n++ )
     {
-    vcl_complex<RealType> c =
-      vnl_complex_traits<vcl_complex<RealType> >::conjugate( Ff[n] );
+    std::complex<RealType> c =
+      vnl_complex_traits<std::complex<RealType> >::conjugate( Ff[n] );
     Gf[n] = c / ( c * Ff[n] + this->m_WeinerFilterNoise );
     }
 
-  vnl_vector<vcl_complex<RealType> > Uf( paddedHistogramSize );
+  vnl_vector<std::complex<RealType> > Uf( paddedHistogramSize );
   for( unsigned int n = 0; n < paddedHistogramSize; n++ )
     {
     Uf[n] = Vf[n] * Gf[n].real();
     }
 
-  vnl_vector<vcl_complex<RealType> > U( Uf );
+  vnl_vector<std::complex<RealType> > U( Uf );
   fft.bwd_transform( U );
   for( unsigned int n = 0; n < paddedHistogramSize; n++ )
     {
-    U[n] = vcl_complex<RealType>( vnl_math_max(
+    U[n] = std::complex<RealType>( vnl_math_max(
                                     U[n].real(), static_cast<RealType>( 0.0 ) ), 0.0 );
     }
 
   /**
    * Compute mapping E(u|v)
    */
-  vnl_vector<vcl_complex<RealType> > numerator( paddedHistogramSize );
+  vnl_vector<std::complex<RealType> > numerator( paddedHistogramSize );
   for( unsigned int n = 0; n < paddedHistogramSize; n++ )
     {
-    numerator[n] = vcl_complex<RealType>(
+    numerator[n] = std::complex<RealType>(
         ( binMinimum + ( static_cast<RealType>( n ) - histogramOffset )
           * histogramSlope ) * U[n].real(), 0.0 );
     }
@@ -477,7 +477,7 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
     }
   fft.bwd_transform( numerator );
 
-  vnl_vector<vcl_complex<RealType> > denominator( U );
+  vnl_vector<std::complex<RealType> > denominator( U );
   fft.fwd_transform( denominator );
   for( unsigned int n = 0; n < paddedHistogramSize; n++ )
     {
@@ -668,7 +668,7 @@ N3MRIBiasFieldCorrectionImageFilter<TInputImage, TMaskImage, TOutputImage>
       mu = mu * ( 1.0 - 1.0 / N ) + pixel / N;
       }
     }
-  sigma = vcl_sqrt( sigma / ( N - 1.0 ) );
+  sigma = std::sqrt( sigma / ( N - 1.0 ) );
 
   /**
    * Although Sled's paper proposes convergence determination via

--- a/Utilities/itkSurfaceCurvatureBase.hxx
+++ b/Utilities/itkSurfaceCurvatureBase.hxx
@@ -14,8 +14,10 @@
 #ifndef _SurfaceCurvatureBase_hxx
 #define _SurfaceCurvatureBase_hxx
 
-#include <vcl_cmath.h>
-#include <vcl_iostream.h>
+#include <vcl_compiler.h>
+#include <iostream>
+#include <cmath>
+#include <iostream>
 #include <vnl/vnl_real_polynomial.h>
 // #include <vnl/algo/vnl_rpoly_roots.h>
 #include <vnl/vnl_vector.h>
@@ -170,11 +172,11 @@ void  SurfaceCurvatureBase<TSurface, TDimension>
     if( m_Debug )
       {
       vnl_vector<double> a = eig.get_eigenvector(0);
-      vcl_cout << "Eig residual = " << (D * a).magnitude() << vcl_endl;
+      std::cout << "Eig residual = " << (D * a).magnitude() << std::endl;
       a = eig.get_eigenvector(1);
-      vcl_cout << "Eig residual = " << (D * a).magnitude() << vcl_endl;
+      std::cout << "Eig residual = " << (D * a).magnitude() << std::endl;
       a = eig.get_eigenvector(2);
-      vcl_cout << "Eig residual = " << (D * a).magnitude() << vcl_endl;
+      std::cout << "Eig residual = " << (D * a).magnitude() << std::endl;
       }
     }
 }
@@ -465,8 +467,8 @@ void  SurfaceCurvatureBase<TSurface, TDimension>
     }
 
 // NOTE: THIS IS THE ERROR ESTIMATE
-// vcl_cout << "SVD residual = " << (D * a).magnitude() << vcl_endl;
-// vcl_cout << " a " << a << vcl_endl;
+// std::cout << "SVD residual = " << (D * a).magnitude() << std::endl;
+// std::cout << " a " << a << std::endl;
 //  MatrixType C(2,2);
 //  C(0,0)=a(0);   C(1,0)=a(1);   C(0,1)=a(1);   C(1,1)=a(2);
 //  vnl_symmetric_eigensystem<double> eig(C);
@@ -555,8 +557,8 @@ void  SurfaceCurvatureBase<TSurface, TDimension>
   vnl_vector<double> c = svd.solve(dists);
 
   // NOTE: THIS IS THE ERROR ESTIMATE
-  // vcl_cout << "SVD residual = " << (D * c).magnitude() << vcl_endl;
-  // vcl_cout << " C " << c << vcl_endl;
+  // std::cout << "SVD residual = " << (D * c).magnitude() << std::endl;
+  // std::cout << " C " << c << std::endl;
 
   MatrixType C(2, 2);
   C(0, 0) = c(0);   C(1, 0) = c(1);   C(0, 1) = c(1);   C(1, 1) = c(2);
@@ -717,7 +719,7 @@ void  SurfaceCurvatureBase<TSurface, TDimension>::TestEstimateTangentPlane(Point
 
   std::cout << " input points " << std::endl;
 
-  vcl_cin >> pts;
+  std::cin >> pts;
 
   // Build cov matrix D
   int        npts = pts.rows();
@@ -757,21 +759,21 @@ void  SurfaceCurvatureBase<TSurface, TDimension>::TestEstimateTangentPlane(Point
     {
     vnl_svd<double>    svd(D);
     vnl_vector<double> a = svd.nullvector();
-    vcl_cout << "SVD residual = " << (D * a).magnitude() << vcl_endl;
-    vcl_cout << "SVD normal " << a << vcl_endl;
+    std::cout << "SVD residual = " << (D * a).magnitude() << std::endl;
+    std::cout << "SVD normal " << a << std::endl;
     }
 
   // 2. Compute using eigensystem of D'*D
     {
     vnl_symmetric_eigensystem<double> eig(D.transpose() * D);
     vnl_vector<double>                a = eig.get_eigenvector(0);
-    vcl_cout << "Eig residual = " << (D * a).magnitude() << vcl_endl;
-    vcl_cout << " normal  " << eig.get_eigenvector(0) << vcl_endl;
-    vcl_cout << "Eigvec 1  " << eig.get_eigenvector(1) << vcl_endl;
-    vcl_cout << "Eigvec 2  " << eig.get_eigenvector(2) << vcl_endl;
-    vcl_cout << "Eigval normal  " << eig.get_eigenvalue(0) << vcl_endl;
-    vcl_cout << "Eigval 1  " << eig.get_eigenvalue(1) << vcl_endl;
-    vcl_cout << "Eigval 2  " << eig.get_eigenvalue(2) << vcl_endl;
+    std::cout << "Eig residual = " << (D * a).magnitude() << std::endl;
+    std::cout << " normal  " << eig.get_eigenvector(0) << std::endl;
+    std::cout << "Eigvec 1  " << eig.get_eigenvector(1) << std::endl;
+    std::cout << "Eigvec 2  " << eig.get_eigenvector(2) << std::endl;
+    std::cout << "Eigval normal  " << eig.get_eigenvalue(0) << std::endl;
+    std::cout << "Eigval 1  " << eig.get_eigenvalue(1) << std::endl;
+    std::cout << "Eigval 2  " << eig.get_eigenvalue(2) << std::endl;
     }
 }
 
@@ -783,7 +785,7 @@ void  SurfaceCurvatureBase<TSurface, TDimension>::FindNeighborhood(unsigned int 
 
   std::cout << " input points " << std::endl;
 
-  vcl_cin >> pts;
+  std::cin >> pts;
 
   // Build cov matrix D
   unsigned int npts = pts.rows();
@@ -1141,7 +1143,7 @@ SurfaceCurvatureBase<TSurface, TDimension>
     // Evaluate results
     //vnl_real_polynomial p(f2);
     //for(unsigned int i = 0; i < p.degree(); i++)
-    //  vnl_test_assert("Root residual", vcl_abs(p.evaluate(roots[i])) < 1e-12);
+    //  vnl_test_assert("Root residual", std::abs(p.evaluate(roots[i])) < 1e-12);
 
     float minrel=9.e9;
     float mins=0.0;

--- a/Utilities/itkSurfaceImageCurvature.hxx
+++ b/Utilities/itkSurfaceImageCurvature.hxx
@@ -681,9 +681,9 @@ void  SurfaceImageCurvature<TSurface>
   // Compute estimated frame using eigensystem of D'*D
     {
     vnl_real_eigensystem eig(W);
-    vnl_diag_matrix<vcl_complex<double> > DD(eig.D.rows() ); //
-    this->m_Kappa1 = vcl_real(eig.D(1, 1) );
-    this->m_Kappa2 = vcl_real(eig.D(0, 0) );
+    vnl_diag_matrix<std::complex<double> > DD(eig.D.rows() ); //
+    this->m_Kappa1 = std::real(eig.D(1, 1) );
+    this->m_Kappa2 = std::real(eig.D(0, 0) );
     this->m_MeanKappa = (this->m_Kappa1 + this->m_Kappa2) * 0.5;
     this->m_GaussianKappa = (this->m_Kappa1 * this->m_Kappa2);
     }

--- a/Utilities/itkTextureHistogram.h
+++ b/Utilities/itkTextureHistogram.h
@@ -88,7 +88,7 @@ public:
         curCount += i->second;
 
         const double p_x = double( i->second ) / count;
-        entropy += -p_x*vcl_log( p_x );
+        entropy += -p_x*std::log( p_x );
 
 //       // this is wrong!
 //       if ( curCount == count / 2 )
@@ -111,7 +111,7 @@ public:
 
 //     while (curCount < count/2 )
 //     {
-//     if ( vcl_fabs( fmedianIt->first - median ) < vcl_fabs( rmedianIt->first - median ) )
+//     if ( std::fabs( fmedianIt->first - median ) < std::fabs( rmedianIt->first - median ) )
 //       {
 //       curCount += fmedianIt->second;
 //       ++fmedianIt;
@@ -129,15 +129,15 @@ public:
 
         // unbiased estimate
       const double variance = ( sum2 - ( sum * sum * icount ) ) / ( count - 1 );
-      const double sigma = vcl_sqrt(variance);
+      const double sigma = std::sqrt(variance);
       double skewness = 0.0;
       double kurtosis = 0.0;
-    if(vcl_abs(variance * sigma) > itk::NumericTraits<double>::min())
+    if(std::abs(variance * sigma) > itk::NumericTraits<double>::min())
       {
 
       skewness = ( ( sum3 - 3.0 * mean * sum2 ) * icount + 2.0 * mean * mean*mean ) / ( variance * sigma );
       }
-    if(vcl_abs(variance) > itk::NumericTraits<double>::min())
+    if(std::abs(variance) > itk::NumericTraits<double>::min())
       {
         kurtosis = ( sum4 * icount  + mean *( -4.0 * sum3 * icount  +  mean * ( 6.0 *sum2 * icount  - 3.0 * mean * mean ))) /
         ( variance * variance ) - 3.0;


### PR DESCRIPTION
In all supported compilers, the need for vcl_ specialized
functions has been removed.  there is no longer a need
to have these overrides, and code is easier to read
and easier to maintain without these specializations.

The vcl_* definitions can now be greatly simplified.
After removing specializations for early non-conformant
c++ compilers the end result was that only the
std:: version of the functions could ever be
used by the compiler.

ITK_SCRIPT=ITK/Utilities/Maintenance/VCL_ModernizeNaming.py
SRC_BASE_DIR=$(pwd)
for ext in ".h" ".cxx" ".cpp" ".hxx" ".hpp" ".txx"; do
  find ${SRC_BASE_DIR} -type f -name "*${ext}" \         -exec python ${ITK_SCRIPT} {} \;
done