### PR TITLE
ENH: Allow advanced users to build only necessary applications.

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -149,9 +149,15 @@ foreach(ANTS_APP ${CORE_ANTS_APPS})
 endforeach()
 
 if (BUILD_ALL_ANTS_APPS)
-foreach(ANTS_APP ${MORE_ANTS_APPS})
-  STANDARD_ANTS_BUILD(${ANTS_APP} "")
-endforeach()
+  foreach(ANTS_APP ${MORE_ANTS_APPS})
+    STANDARD_ANTS_BUILD(${ANTS_APP} "")
+  endforeach()
+else(BUILD_ALL_ANTS_APPS)
+  foreach(ANTS_APP ${MORE_ANTS_APPS})
+    if(ANTS_BUILD_${ANTS_APP})
+      STANDARD_ANTS_BUILD(${ANTS_APP} "")
+    endif()
+  endforeach()
 endif(BUILD_ALL_ANTS_APPS)
 
 


### PR DESCRIPTION
Exposing all applications in CMake would be too much considering that there are more
than 80 applications built as part of ANTS. This commit introduces advanced options
that are not visible in CMake's user interface, that allow to pick only the
tools that ones wants to build when BUILD_ALL_ANTS_APPS is set to OFF.
If one wants to build 'StackSlices', they need to pass an extra variable called
ANTS_BUILD_StackSlices to CMake and set it to ON.
e.g: cmake -DANTS_SUPERBUILD:BOOL=OFF -DBUILD_ALL_ANTS_APPS:BOOL=OFF\
      -DANTS_BUILD_StackSlices=ON ../ANTs
More generally, one needs to use the variable 'ANTS_BUILD_${ANTS_APP}' to build
${ANTS_APP}.