### PR TITLE
BUG: Valgrind detected uninitialized variable

### DIFF
--- a/Utilities/itkAdaptiveNonLocalMeansDenoisingImageFilter.hxx
+++ b/Utilities/itkAdaptiveNonLocalMeansDenoisingImageFilter.hxx
@@ -43,6 +43,7 @@ AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage, TMaskImage>
   m_Epsilon( 0.00001 ),
   m_MeanThreshold( 0.95 ),
   m_VarianceThreshold( 0.5 ),
+  m_SmoothingFactor( 1.0 ),
   m_SmoothingVariance( 2.0 ),
   m_MaximumInputPixelIntensity( NumericTraits<RealType>::NonpositiveMin() ),
   m_MinimumInputPixelIntensity( NumericTraits<RealType>::max() )


### PR DESCRIPTION
Denoise image filter was behaving erratically an that
often caused images with very poor output quality to be produced.

Initializing this variable did not fix the overall problem.