### PR TITLE
Work in Progress: Enable compression ImageFileWriter calls

### DIFF
--- a/Utilities/ReadWriteData.h
+++ b/Utilities/ReadWriteData.h
@@ -520,6 +520,7 @@ bool WriteImage(const itk::SmartPointer<TImageType> image, const char *file)
       std::exception();
       }
     writer->SetInput(image);
+    writer->SetUseCompression( true );
     writer->Update();
     }
   return true;
@@ -556,6 +557,7 @@ void WriteTensorImage(itk::SmartPointer<TImageType> image, const char *file, boo
   else
     {
     writer->SetInput(writeImage);
+    writer->SetUseCompression( true );
     writer->Update();
     }
 }


### PR DESCRIPTION
ImageFileWriter offers a SetUseCompression option which turns on compression:
http://www.itk.org/Doxygen/html/classitk_1_1ImageFileWriter.html#a8afafaf0d9fe64cfcbb5100d01509dd4

For writers that support compression this turns it on internally during writing, for those that don't support it, it appears to be a no-op.

This feature is particularly important for the MINC format, which has internal lossless compression. Right now ANTs produces *huge* MINC files because compression is disabled. It does not appear to have an impact on .nii and .nii.gz outputs from my testing.


Questions:
- would you accept changes to all instances of ImageFileWriter in the ANTs codebase? Right now MINC displacement transforms are still uncompressed in this patch
- should this be controllable via a command-line option or environment variable?

