### PR TITLE
BUG: cleanup function in bash scripts killed all matching processes

### DIFF
--- a/Scripts/antsIntroduction.sh
+++ b/Scripts/antsIntroduction.sh
@@ -276,28 +276,19 @@ dataCheck
 
 }
 
+
 cleanup()
-# example cleanup function
 {
-
-  cd ${currentdir}/
-
-  echo -en "\n*** Performing cleanup, please wait ***\n"
-
-# 1st attempt to kill all remaining processes
-# put all related processes in array
-  runningANTSpids=( `ps -C ANTS -C N4BiasFieldCorrection -C antsIntroduction.sh | awk '{ printf "%s\n", $1 ; }'` )
-
-# debug only
-  #echo list 1: ${runningANTSpids[@]}
-
-# kill these processes, skip the first since it is text and not a PID
-  for ((i = 1; i < ${#runningANTSpids[@]} ; i++))
+  echo "\n*** Performing cleanup, please wait ***\n"
+  
+  runningANTSpids=$( ps --ppid $$ -o pid= )
+  
+  for thePID in $runningANTSpids
   do
-  echo "killing:  ${runningANTSpids[${i}]}"
-  kill ${runningANTSpids[${i}]}
+      echo "killing:  ${thePID}"
+      kill ${thePID}
   done
-
+  
   return $?
 }
 

--- a/Scripts/antsJointLabelFusion.sh
+++ b/Scripts/antsJointLabelFusion.sh
@@ -312,18 +312,15 @@ REPORTPARAMETERS
 cleanup()
 {
   echo "\n*** Performing cleanup, please wait ***\n"
-
-# 1st attempt to kill all remaining processes
-# put all related processes in array
-runningANTSpids=( `ps -C antsRegistration -C ImageMath| awk '{ printf "%s\n", $1 ; }'` )
-
-# kill these processes, skip the first since it is text and not a PID
-for ((i = 1; i < ${#runningANTSpids[@]} ; i++))
+  
+  runningANTSpids=$( ps --ppid $$ -o pid= )
+  
+  for thePID in $runningANTSpids
   do
-  echo "killing:  ${runningANTSpids[${i}]}"
-  kill ${runningANTSpids[${i}]}
-done
-
+      echo "killing:  ${thePID}"
+      kill ${thePID}
+  done
+  
   return $?
 }
 

--- a/Scripts/antsMalfLabeling.sh
+++ b/Scripts/antsMalfLabeling.sh
@@ -256,21 +256,19 @@ function reportParameters {
 REPORTPARAMETERS
 }
 
+
 cleanup()
 {
   echo "\n*** Performing cleanup, please wait ***\n"
-
-# 1st attempt to kill all remaining processes
-# put all related processes in array
-runningANTSpids=( `ps -C antsRegistration -C ImageMath| awk '{ printf "%s\n", $1 ; }'` )
-
-# kill these processes, skip the first since it is text and not a PID
-for ((i = 1; i < ${#runningANTSpids[@]} ; i++))
+  
+  runningANTSpids=$( ps --ppid $$ -o pid= )
+  
+  for thePID in $runningANTSpids
   do
-  echo "killing:  ${runningANTSpids[${i}]}"
-  kill ${runningANTSpids[${i}]}
-done
-
+      echo "killing:  ${thePID}"
+      kill ${thePID}
+  done
+  
   return $?
 }
 

--- a/Scripts/antsMultivariateTemplateConstruction.sh
+++ b/Scripts/antsMultivariateTemplateConstruction.sh
@@ -307,27 +307,17 @@ done
 }
 
 cleanup()
-# example cleanup function
 {
-
-  cd ${currentdir}/
-
-  echo -en "\n*** Performing cleanup, please wait ***\n"
-
-# 1st attempt to kill all remaining processes
-# put all related processes in array
-  runningANTSpids=( `ps -C ANTS -C N4BiasFieldCorrection -C ImageMath| awk '{ printf "%s\n", $1 ; }'` )
-
-# debug only
-  #echo list 1: ${runningANTSpids[@]}
-
-# kill these processes, skip the first since it is text and not a PID
-  for ((i = 1; i < ${#runningANTSpids[@]} ; i++))
+  echo "\n*** Performing cleanup, please wait ***\n"
+  
+  runningANTSpids=$( ps --ppid $$ -o pid= )
+  
+  for thePID in $runningANTSpids
   do
-  echo "killing:  ${runningANTSpids[${i}]}"
-  kill ${runningANTSpids[${i}]}
+      echo "killing:  ${thePID}"
+      kill ${thePID}
   done
-
+  
   return $?
 }
 

--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -427,27 +427,17 @@ for (( g = $WHICHMODALITY; g < ${#IMAGESETARRAY[@]}; g+=$NUMBEROFMODALITIES ))
 }
 
 cleanup()
-# example cleanup function
 {
-
-  cd ${currentdir}/
-
   echo "\n*** Performing cleanup, please wait ***\n"
-
-# 1st attempt to kill all remaining processes
-# put all related processes in array
-runningANTSpids=( `ps -C antsRegistration -C N4BiasFieldCorrection -C ImageMath| awk '{ printf "%s\n", $1 ; }'` )
-
-# debug only
-  #echo list 1: ${runningANTSpids[@]}
-
-# kill these processes, skip the first since it is text and not a PID
-for ((i = 1; i < ${#runningANTSpids[@]} ; i++))
+  
+    runningANTSpids=$( ps --ppid $$ -o pid= )
+  
+  for thePID in $runningANTSpids
   do
-  echo "killing:  ${runningANTSpids[${i}]}"
-  kill ${runningANTSpids[${i}]}
-done
-
+      echo "killing:  ${thePID}"
+      kill ${thePID}
+  done
+  
   return $?
 }
 

--- a/Scripts/antsRegistrationSpaceTime.sh
+++ b/Scripts/antsRegistrationSpaceTime.sh
@@ -163,7 +163,7 @@ script by Nick Tustison
 
 HELP
     exit 1
-}
+
 
 function reportMappingParameters {
     cat <<REPORTMAPPINGPARAMETERS
@@ -187,27 +187,17 @@ REPORTMAPPINGPARAMETERS
 }
 
 cleanup()
-# example cleanup function
 {
-
-  cd ${currentdir}/
-
   echo "\n*** Performing cleanup, please wait ***\n"
-
-# 1st attempt to kill all remaining processes
-# put all related processes in array
-runningANTSpids=( `ps -C antsRegistration | awk '{ printf "%s\n", $1 ; }'` )
-
-# debug only
-  #echo list 1: ${runningANTSpids[@]}
-
-# kill these processes, skip the first since it is text and not a PID
-for (( i = 1; i < ${#runningANTSpids[@]}; i++ ))
+  
+  runningANTSpids=$( ps --ppid $$ -o pid= )
+  
+  for thePID in $runningANTSpids
   do
-    echo "killing:  ${runningANTSpids[${i}]}"
-    kill ${runningANTSpids[${i}]}
-done
-
+      echo "killing:  ${thePID}"
+      kill ${thePID}
+  done
+  
   return $?
 }
 

--- a/Scripts/antsRegistrationSyN.sh
+++ b/Scripts/antsRegistrationSyN.sh
@@ -218,27 +218,17 @@ REPORTMAPPINGPARAMETERS
 }
 
 cleanup()
-# example cleanup function
 {
-
-  cd ${currentdir}/
-
   echo "\n*** Performing cleanup, please wait ***\n"
-
-# 1st attempt to kill all remaining processes
-# put all related processes in array
-runningANTSpids=( `ps -C antsRegistration | awk '{ printf "%s\n", $1 ; }'` )
-
-# debug only
-  #echo list 1: ${runningANTSpids[@]}
-
-# kill these processes, skip the first since it is text and not a PID
-for (( i = 1; i < ${#runningANTSpids[@]}; i++ ))
+  
+    runningANTSpids=$( ps --ppid $$ -o pid= )
+  
+  for thePID in $runningANTSpids
   do
-    echo "killing:  ${runningANTSpids[${i}]}"
-    kill ${runningANTSpids[${i}]}
-done
-
+      echo "killing:  ${thePID}"
+      kill ${thePID}
+  done
+  
   return $?
 }
 

--- a/Scripts/antsRegistrationSyNQuick.sh
+++ b/Scripts/antsRegistrationSyNQuick.sh
@@ -218,29 +218,20 @@ REPORTMAPPINGPARAMETERS
 }
 
 cleanup()
-# example cleanup function
 {
-
-  cd ${currentdir}/
-
   echo "\n*** Performing cleanup, please wait ***\n"
-
-# 1st attempt to kill all remaining processes
-# put all related processes in array
-runningANTSpids=( `ps -C antsRegistration | awk '{ printf "%s\n", $1 ; }'` )
-
-# debug only
-  #echo list 1: ${runningANTSpids[@]}
-
-# kill these processes, skip the first since it is text and not a PID
-for (( i = 1; i < ${#runningANTSpids[@]}; i++ ))
+  
+  runningANTSpids=$( ps --ppid $$ -o pid= )
+  
+  for thePID in $runningANTSpids
   do
-    echo "killing:  ${runningANTSpids[${i}]}"
-    kill ${runningANTSpids[${i}]}
-done
-
+      echo "killing:  ${thePID}"
+      kill ${thePID}
+  done
+  
   return $?
 }
+
 
 control_c()
 # run if user hits control-c

--- a/Scripts/buildtemplateparallel.sh
+++ b/Scripts/buildtemplateparallel.sh
@@ -591,28 +591,19 @@ function jobfnamepadding {
 
 }
 
+
 cleanup()
-# example cleanup function
 {
-
-  cd ${currentdir}/
-
-  echo -en "\n*** Performing cleanup, please wait ***\n"
-
-# 1st attempt to kill all remaining processes
-# put all related processes in array
-  runningANTSpids=( `ps -C ANTS -C N4BiasFieldCorrection -C ImageMath| awk '{ printf "%s\n", $1 ; }'` )
-
-# debug only
-  #echo list 1: ${runningANTSpids[@]}
-
-# kill these processes, skip the first since it is text and not a PID
-  for ((i = 1; i < ${#runningANTSpids[@]} ; i++))
+  echo "\n*** Performing cleanup, please wait ***\n"
+  
+  runningANTSpids=$( ps --ppid $$ -o pid= )
+  
+  for thePID in $runningANTSpids
   do
-  echo "killing:  ${runningANTSpids[${i}]}"
-  kill ${runningANTSpids[${i}]}
+      echo "killing:  ${thePID}"
+      kill ${thePID}
   done
-
+  
   return $?
 }
 


### PR DESCRIPTION
The "cleanup" function in the various bash scripts did something like

```
runningANTSpids=( `ps -C antsRegistration -C ImageMath| awk '{ printf "%s\n", $1 ; }'` )
```

This does a system-wide trawl of the matching commands (varies by script), including all users. It's unlikely that you could kill other people's jobs unless you're root, but you can kill jobs of your own that are unrelated to the script you're trying to stop. 

I replaced this line with

```
 runningANTSpids=$( ps --ppid $$ -o pid= )
```

which attempts to kill off child processes of the script. This includes the ps command itself, which will always finish before it can be killed, but it won't affect programs not launched from the script.