### PR TITLE
Switch ITK URL to github

### DIFF
--- a/SuperBuild/External_ITKv4.cmake
+++ b/SuperBuild/External_ITKv4.cmake
@@ -160,7 +160,7 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
 
 
   ### --- End Project specific additions
-  set(${proj}_REPOSITORY ${git_protocol}://itk.org/ITK.git)
+  set(${proj}_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git)
   set(${proj}_GIT_TAG fc03bcc92b11326b87c232c14eb234fc1f791f9f) ##
   set(ITK_VERSION_ID ITK-4.9) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID
 


### PR DESCRIPTION
ITK.org is 4-5x slower than github (likely due to github's cloud hosting)

Switching the URL substantially improves download times. It sill supports both git:// and https://