### PR TITLE
Update ITKv4 commitid to pull in MINC/libnifti confusion fix

### DIFF
--- a/SuperBuild/External_ITKv4.cmake
+++ b/SuperBuild/External_ITKv4.cmake
@@ -161,8 +161,8 @@ if(NOT DEFINED ${extProjName}_DIR AND NOT ${USE_SYSTEM_${extProjName}})
 
   ### --- End Project specific additions
   set(${proj}_REPOSITORY ${git_protocol}://github.com/InsightSoftwareConsortium/ITK.git)
-  set(${proj}_GIT_TAG fc03bcc92b11326b87c232c14eb234fc1f791f9f) ##
-  set(ITK_VERSION_ID ITK-4.9) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID
+  set(${proj}_GIT_TAG f60bbd3aadc4b9fbf2cff1cf7227cef1e92b979a) ##
+  set(ITK_VERSION_ID ITK-4.10) ### NOTE: When updating GIT_TAG, also update ITK_VERSION_ID
 
   ExternalProject_Add(${proj}
     GIT_REPOSITORY ${${proj}_REPOSITORY}


### PR DESCRIPTION
Enabling MINC support was breaking nifti loading/writing in ANTs due to MINC support including it's own libnifti. Update to latest MINC resync on ITK to fix.

This fixes #270 