### PR TITLE
ExtractSliceFromImage - use header information for 3D slices

### DIFF
--- a/Examples/ExtractSliceFromImage.cxx
+++ b/Examples/ExtractSliceFromImage.cxx
@@ -29,7 +29,7 @@ int ExtractSliceFromImage( int itkNotUsed( argc ), char *argv[] )
   typename ExtracterType::Pointer extracter = ExtracterType::New();
   extracter->SetInput( inputImage );
   extracter->SetExtractionRegion( region );
-  extracter->SetDirectionCollapseToIdentity();
+  extracter->SetDirectionCollapseToSubmatrix();
   extracter->Update();
 
   WriteImage<SliceType>( extracter->GetOutput(), argv[3] );

--- a/Examples/ExtractSliceFromImage.cxx
+++ b/Examples/ExtractSliceFromImage.cxx
@@ -29,8 +29,16 @@ int ExtractSliceFromImage( int itkNotUsed( argc ), char *argv[] )
   typename ExtracterType::Pointer extracter = ExtracterType::New();
   extracter->SetInput( inputImage );
   extracter->SetExtractionRegion( region );
-  extracter->SetDirectionCollapseToSubmatrix();
+  if (ImageDimension < 4)
+    {
+    extracter->SetDirectionCollapseToIdentity();
+    }
+  else 
+    {
+    extracter->SetDirectionCollapseToSubmatrix();
+    }
   extracter->Update();
+
 
   WriteImage<SliceType>( extracter->GetOutput(), argv[3] );
 


### PR DESCRIPTION
Use header information so that 3D slices from a 4D volume retain their origin and orientation.