### PR TITLE
Fixed floating point error in ImageMath:LabelStats

### DIFF
--- a/Examples/ImageMath.cxx
+++ b/Examples/ImageMath.cxx
@@ -10192,7 +10192,6 @@ int LabelStats(      int argc, char *argv[])
       PixelType label = It.Get();
       if(  label == currentlabel  )
         {
-        totalvolume += volumeelement;
         totalct += 1;
         if( valimage )
           {
@@ -10208,6 +10207,9 @@ int LabelStats(      int argc, char *argv[])
           }
         }
       }
+
+    totalvolume = volumeelement * totalct;
+
     for( unsigned int i = 0; i < spacing.Size(); i++ )
       {
       myCenterOfMass[i] /= (float)totalct;


### PR DESCRIPTION
Fixed an error in volume calculation in ImageMath's LabelStats function. Volume was being calculated by accumulation, which leads to error with floating point values. Replaced by direct multiplication of voxel volume by voxel count.