### PR TITLE
Add link to benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ here](https://sourceforge.net/p/advants/discussion/840261/thread/1cb7b165/?limit
 
 Brief ANTs segmentation [video](http://vimeo.com/67814201)
 
+**Benchmarks** [results](https://github.com/gdevenyi/antsRegistration-benchmarking)
+
 References
 ----------------------------------------------------------
 


### PR DESCRIPTION
I recently performed some fixed/moving benchmarks for walltime and memory of antsRegistration.

Thought they might be useful.