### PR TITLE
Enable ccache in cmake, and speedup travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,30 @@ os:
 
 language: cpp
 
+cache: ccache
+
 compiler:
   - clang
+  - gcc
+
+addons:
+  apt:
+    sources:
+      - george-edison55-precise-backports
+    packages:
+      - cmake
+      - cmake-data
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then wget --no-check-certificate https://cmake.org/files/v3.4/cmake-3.4.0-rc1-Linux-x86_64.sh; sh cmake-3.4.0-rc1-Linux-x86_64.sh --skip-license --prefix=${HOME}; export PATH=$HOME/bin/:$PATH; fi
   - if [ "$TRAVIS_OS_NAME" == "osx" ];  then echo "need cmake 3.2"; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew update && brew install ccache; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then export PATH="/usr/local/opt/ccache/libexec:$PATH"; fi
   - mkdir antsbin
   - cd antsbin
+
 script:
   - cmake -DRUN_LONG_TESTS=OFF -DRUN_SHORT_TESTS=ON ./.. && make -j 2 && cd ANTS-build/ && make test
+
 notifications:
   email:
     recipients:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 2.8.9)
 cmake_policy(VERSION 2.8.9)
 
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
+endif()
+
 set(LIBRARY_SOVERSION_INFO 2)
 set(LIBRARY_VERSION_INFO 2.1.0)
 


### PR DESCRIPTION
ccache on travis cuts down on build times from ~40 minutes to ~15 minutes

Ex:
https://travis-ci.org/gdevenyi/ANTs/builds/148149544

The *first time* on OSX builds is *very* close to the 50 minute limit on travis, if this is the case, disabling the tests "-DRUN_SHORT_TESTS=OFF" for one cycle will successfully prime the cache.