### PR TITLE
Enable operating on MINC transforms for some utilities

### DIFF
--- a/Examples/antsUtilities.cxx
+++ b/Examples/antsUtilities.cxx
@@ -29,7 +29,7 @@ TRAN_FILE_TYPE CheckFileType(const char * const str)
       pos = filepre.rfind( "." );
       extension = std::string( filepre, pos, filepre.length() - 1 );
       }
-    if( extension == ".txt" || extension == ".mat" || extension == ".hdf5" || extension == ".hdf" )
+    if( extension == ".txt" || extension == ".mat" || extension == ".hdf5" || extension == ".hdf" || extension == ".xfm")
       {
       return AFFINE_FILE;
       }


### PR DESCRIPTION
This allows tools such as AverageAffineTransforms to properly read/write MINC xfm files (if ITK has MINC support built in).

Gives comparable results to https://github.com/BIC-MNI/pyezminc/blob/master/examples/xfmavg_scipy.py