### PR TITLE
Update buildtemplateparallel.sh

### DIFF
--- a/Scripts/buildtemplateparallel.sh
+++ b/Scripts/buildtemplateparallel.sh
@@ -1226,7 +1226,8 @@ while [  $i -lt ${ITERATIONLIMIT} ]
       id=`xgrid $XGRIDOPTS -job submit /bin/bash $qscript | awk '{sub(/;/,"");print $3}' | tr '\n' ' ' | sed 's:  *: :g'`
       jobIDs="$jobIDs $id"
       qscript="job_${count}_${i}.sh"
-    elif [[ $DOQSUB -eq 5 ]]; then
+    elif [[ $DOQSUB -eq 5 ]] ; then
+      qscript="job_${count}_${i}.sh"
       echo '#!/bin/sh' > $qscript
       echo -e "$SCRIPTPREPEND" >> $qscript
       echo -e "$exe" >> $qscript


### PR DESCRIPTION
The initial qscript name was missing for the SLURM option, so I was getting the following error: 
line 1230: $qscript: ambiguous redirect
line 1231: $qscript: ambiguous redirect
line 1232: $qscript: ambiguous redirect