### PR TITLE
Fix VTK Superbuild

### DIFF
--- a/ANTS.cmake
+++ b/ANTS.cmake
@@ -54,8 +54,25 @@ option(BUILD_ALL_ANTS_APPS "Use All ANTs Apps" ON)
 option(USE_VTK "Use VTK Libraries" OFF)
 if(USE_VTK)
   find_package(VTK)
+  find_package(VTK COMPONENTS
+   vtkCommonCore
+   vtkCommonDataModel
+   vtkIOGeometry
+   vtkIOXML
+   vtkIOLegacy
+   vtkIOPLY
+   vtkFiltersModeling
+   vtkImagingStencil
+   vtkImagingGeneral
+   vtkRenderingAnnotation
+   vtkRenderingVolumeOpenGL
+ #   vtkRenderingVolumeOpenGL2 # VTK7
+   )
+
   if(VTK_FOUND)
     include(${VTK_USE_FILE})
+    include_directories(${VTK_INCLUDE_DIRS})
+    set(INIT_VTK_LIBRARIES ${VTK_LIBRARIES})
   else(VTK_FOUND)
      message("Cannot build some programs without VTK.  Please set VTK_DIR if you need these programs.")
   endif(VTK_FOUND)

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -168,26 +168,8 @@ endif(BUILD_ALL_ANTS_APPS)
 
 
 if(USE_VTK)
-find_package(VTK REQUIRED NO_MODULE)
-find_package(VTK COMPONENTS
-   vtkCommonCore
-   vtkCommonDataModel
-   vtkIOGeometry
-   vtkIOXML
-   vtkIOLegacy
-   vtkIOPLY
-   vtkFiltersModeling
-   vtkImagingStencil
-   vtkImagingGeneral
-   vtkRenderingAnnotation
-   vtkRenderingVolumeOpenGL
-#   vtkRenderingVolumeOpenGL2 # VTK7
-   )
-include(${VTK_USE_FILE})
-include_directories(${VTK_INCLUDE_DIRS})
-
 set(VTK_ANTS_APPS
-#    ConvertVectorFieldToVTK
+    # ConvertVectorFieldToVTK
     antsSurf
     antsVol
     GetMeshAndTopology

--- a/SuperBuild/External_VTK.cmake
+++ b/SuperBuild/External_VTK.cmake
@@ -195,7 +195,8 @@ if(NOT ( DEFINED "USE_SYSTEM_${extProjName}" AND "${USE_SYSTEM_${extProjName}}" 
 #    -P ${VTKPatchScript}
 #    )
 
-  set(${extProjName}_DIR ${CMAKE_BINARY_DIR}/${proj}-install/lib/vtk-6.2)
+set(${extProjName}_DIR ${CMAKE_BINARY_DIR}/${proj}-install)
+
 else()
   if(${USE_SYSTEM_${extProjName}})
     find_package(${extProjName} ${${extProjName}_REQUIRED_VERSION} REQUIRED)


### PR DESCRIPTION
This commit fixes the build system for VTK so that the superbuild works properly.

Through my testing it works for the VTK hash currently set, as well as the very latest 7.x release.

It also still built fine with my system VTK