### PR TITLE
Allow for both VTK versions during build

### DIFF
--- a/ANTS.cmake
+++ b/ANTS.cmake
@@ -65,9 +65,13 @@ if(USE_VTK)
    vtkImagingStencil
    vtkImagingGeneral
    vtkRenderingAnnotation
-   vtkRenderingVolumeOpenGL
- #   vtkRenderingVolumeOpenGL2 # VTK7
    )
+
+  if(VTK_VERSION_MAJOR GREATER 6)
+    find_package(VTK COMPONENTS vtkRenderingVolumeOpenGL2)
+  else(VTK_VERSION_MAJOR GREATER 6)
+     find_package(VTK COMPONENTS vtkRenderingVolumeOpenGL)
+  endif(VTK_VERSION_MAJOR GREATER 6)
 
   if(VTK_FOUND)
     include(${VTK_USE_FILE})


### PR DESCRIPTION
Check the major version of VTK and find the OpenGL rendering component based on this.

Warning: this can still cause problems if VTK7 was built with the old rendering backend. I don't know how to do a "this component OR that component" test in CMake.
