### PR TITLE
Vtk examples fix

### DIFF
--- a/ANTS.cmake
+++ b/ANTS.cmake
@@ -65,9 +65,13 @@ if(USE_VTK)
    vtkImagingStencil
    vtkImagingGeneral
    vtkRenderingAnnotation
-   vtkRenderingVolumeOpenGL
- #   vtkRenderingVolumeOpenGL2 # VTK7
    )
+
+  if(VTK_VERSION_MAJOR GREATER 6)
+    find_package(VTK COMPONENTS vtkRenderingVolumeOpenGL2)
+  else(VTK_VERSION_MAJOR GREATER 6)
+     find_package(VTK COMPONENTS vtkRenderingVolumeOpenGL)
+  endif(VTK_VERSION_MAJOR GREATER 6)
 
   if(VTK_FOUND)
     include(${VTK_USE_FILE})

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -27,7 +27,7 @@ macro(STANDARD_ANTS_BUILD ANTS_FUNCTION_NAME EXTRA_LIBS)
   SET_TARGET_PROPERTIES(l_${ANTS_FUNCTION_NAME} PROPERTIES
     SOVERSION ${LIBRARY_SOVERSION_INFO}  VERSION ${LIBRARY_VERSION_INFO})
   message(STATUS "${ANTS_FUNCTION_NAME} ${EXTRA_LIBS}")
-  target_link_libraries(l_${ANTS_FUNCTION_NAME} antsUtilities ${EXTRA_LIBS} )
+  target_link_libraries(l_${ANTS_FUNCTION_NAME} antsUtilities ${EXTRA_LIBS} vtkImagingStencil vtkIOGeometry vtkRenderingAnnotation vtkIOPLY)
   configure_file( template_for_executables.cxx.in cli_${ANTS_FUNCTION_NAME}.cxx )
   add_executable( ${ANTS_FUNCTION_NAME} cli_${ANTS_FUNCTION_NAME}.cxx )
   target_link_libraries( ${ANTS_FUNCTION_NAME} l_${ANTS_FUNCTION_NAME} )


### PR DESCRIPTION
These changes in the Examples/CMakelists.txt file allow ANTs to build.  Some changes were made to VTK recently that breaks the ANTs compile.  This successfully built after applying another applying gdevenyi's vtk-fix