### PR TITLE
Allow for larger kernel sizes in the case of high-resolution data

### DIFF
--- a/Examples/SmoothImage.cxx
+++ b/Examples/SmoothImage.cxx
@@ -38,6 +38,8 @@ int SmoothImage(int argc, char *argv[])
   typename dgf::Pointer filter = dgf::New();
   typename medf::Pointer filter2 = medf::New();
   bool usespacing = false;
+  float gaussianmaxerror = 0.01;
+  int gaussianmaxkernelwidth = 32;
   if( argc  >  5 )
     {
     usespacing = atoi(argv[5]);
@@ -46,6 +48,14 @@ int SmoothImage(int argc, char *argv[])
   if( argc  >  6 )
     {
     usemedian = atoi(argv[6]);
+    }
+  if( argc  >  7 )
+    {
+    gaussianmaxerror = atof(argv[7]);
+    }
+  if( argc  >  8 )
+    {
+    gaussianmaxkernelwidth = atoi(argv[8]);
     }
   if( !usespacing )
     {
@@ -75,7 +85,8 @@ int SmoothImage(int argc, char *argv[])
       {
       std::cerr << "Incorrect sigma vector size.  Must either be of size 1 or ImageDimension." << std::endl;
       }
-    filter->SetMaximumError( 0.01f );
+    filter->SetMaximumError( gaussianmaxerror );
+    filter->SetMaximumKernelWidth( gaussianmaxkernelwidth );
     filter->SetInput( image1 );
     filter->Update();
     varimage = filter->GetOutput();
@@ -158,7 +169,7 @@ private:
     std::cout << "Usage:  " << std::endl;
     std::cout << argv[0]
              <<
-      " ImageDimension image.ext smoothingsigma outimage.ext {sigma-is-in-spacing-coordinates-0/1} {medianfilter-0/1}"
+      " ImageDimension image.ext smoothingsigma outimage.ext {sigma-is-in-spacing-coordinates-0/1} {medianfilter-0/1} {GaussianSetMaximumError=0.01} {GaussianSetMaximumKernelWidth=32}"
              << std::endl;
     std::cout << " if median, then sigma means radius of filtering " << std::endl;
     std::cout << " A separate sigma can be specified for each dimension, e.g., 1.5x1x2 " << std::endl;


### PR DESCRIPTION
When blurring high resolution data with large blurs, sometimes the we run into the maximum kernel with of 32. Increase this to a larger number so that in those cases the kernel isn't truncated.

Has no impact to cases where blur kernel isn't truncated because this is just the maximum.