### PR TITLE
COMP: Silence ITK_OVERRIDE warning for virtual methods

### DIFF
--- a/ImageRegistration/itkLabelImageGenericInterpolateImageFunction.h
+++ b/ImageRegistration/itkLabelImageGenericInterpolateImageFunction.h
@@ -64,12 +64,12 @@ public:
    * Evaluate at the given index
    */
   virtual OutputType EvaluateAtContinuousIndex(
-    const ContinuousIndexType & cindex ) const
+    const ContinuousIndexType & cindex ) const ITK_OVERRIDE
     {
     return this->EvaluateAtContinuousIndex( cindex, NULL );
     }
 
-	virtual void SetInputImage( const TInputImage *image );
+  virtual void SetInputImage( const TInputImage *image ) ITK_OVERRIDE;
 
 protected:
   LabelImageGenericInterpolateImageFunction();


### PR DESCRIPTION
ANTs/ImageRegistration/itkLabelImageGenericInterpolateImageFunction.h:66:22: warning: 'EvaluateAtContinuousIndex' overrides a member
      function but is not marked 'override' [-Winconsistent-missing-override]
  virtual OutputType EvaluateAtContinuousIndex(

When compiling with C++11, use the extra ITK_OVERRIDE to ensure that function
overriding is properly used.