### PR TITLE
BUG: Fix uninitialized image arrays used by denoiser.

### DIFF
--- a/Utilities/itkAdaptiveNonLocalMeansDenoisingImageFilter.hxx
+++ b/Utilities/itkAdaptiveNonLocalMeansDenoisingImageFilter.hxx
@@ -98,16 +98,14 @@ AdaptiveNonLocalMeansDenoisingImageFilter<TInputImage, TOutputImage, TMaskImage>
   this->m_ThreadContributionCountImage = RealImageType::New();
   this->m_ThreadContributionCountImage->CopyInformation( inputImage );
   this->m_ThreadContributionCountImage->SetRegions( inputImage->GetRequestedRegion() );
-  this->m_ThreadContributionCountImage->Allocate(0.0);
-  //this->m_ThreadContributionCountImage->FillBuffer( 0.0 );
+  this->m_ThreadContributionCountImage->Allocate(true); // initializes buffer with 0
 
   if( this->m_UseRicianNoiseModel )
     {
     this->m_RicianBiasImage = RealImageType::New();
     this->m_RicianBiasImage->CopyInformation( inputImage );
     this->m_RicianBiasImage->SetRegions( inputImage->GetRequestedRegion() );
-    this->m_RicianBiasImage->Allocate(0.0);
-    //this->m_RicianBiasImage->FillBuffer( 0.0 );
+    this->m_RicianBiasImage->Allocate(true); // initializes buffer with 0
     }
 
   ConstNeighborhoodIterator<InputImageType> ItBI( this->m_NeighborhoodPatchRadius,


### PR DESCRIPTION
Hello,

I am integrating the Adaptive Non-Local Means filter into my own project and noticed it was producing some nonsensical output when compiled as "Debug" with Visual Studio 2013.  After some debugging, I discovered the root cause to be uninitialized values which I found using valgrind's memcheck tool (this time compiled with gcc, of course).  See valgrind report below.

It seems that `itk::Image::Allocate` was used with a `0.0` argument thinking this was the value to fill the buffer with.  That argument is actually a `bool` which, when true, fills the buffer using the type's default constructor.  I did some `grep`ping and did not find `Allocate` used in this way elsewhere.

Thanks

`==7430== Conditional jump or move depends on uninitialised value(s)
==7430==    at 0x6D59151: itk::AdaptiveNonLocalMeansDenoisingImageFilter<itk::Image<float, 3u>, itk::Image<float, 3u>, itk::Image<unsigned char, 3u> >::AfterThreadedGenerateData() (itkAdaptiveNonLocalMeansDenoisingImageFilter.hxx:485)
==7430==    by 0x65A34AB: itk::ImageSource<itk::Image<float, 3u> >::GenerateData() (itkImageSource.hxx:258)
==7430==    by 0x863EDC6: itk::ProcessObject::UpdateOutputData(itk::DataObject*) (in /mnt/storage/vivoquant/BUILD-dbg/libinvicro.so)
==7430==    by 0x654FEF7: itk::ImageBase<3u>::UpdateOutputData() (itkImageBase.hxx:287)
==7430==    by 0x6D4FE61: itk::AdaptiveNLMeansWithShrinkImageFilter<itk::Image<float, 3u> >::GenerateData() (itkAdaptiveNLMeansWithShrinkImageFilter.hxx:70)
==7430==    by 0x863EDC6: itk::ProcessObject::UpdateOutputData(itk::DataObject*) (in /mnt/storage/vivoquant/BUILD-dbg/libinvicro.so)
==7430==    by 0x654FEF7: itk::ImageBase<3u>::UpdateOutputData() (itkImageBase.hxx:287)
==7430==    by 0x6D2FF4F: SmoothingOperator::applyFilter(TRasterTemplate<float, float>*, itk::SmartPointer<itk::ImageToImageFilter<itk::Image<float, 3u>, itk::Image<float, 3u> > >) (SmoothingOperator.cpp:698)
==7430==  Uninitialised value was created by a heap allocation
==7430==    at 0x4A07192: operator new[](unsigned long) (in /opt/rh/devtoolset-2/root/usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==7430==    by 0x65AA4A9: itk::ImportImageContainer<unsigned long, float>::AllocateElements(unsigned long, bool) const (itkImportImageContainer.hxx:188)
==7430==    by 0x65AD3A2: itk::ImportImageContainer<unsigned long, float>::Reserve(unsigned long, bool) (itkImportImageContainer.hxx:90)
==7430==    by 0x65A9E73: itk::Image<float, 3u>::Allocate(bool) (itkImage.hxx:57)
==7430==    by 0x6D588AD: itk::AdaptiveNonLocalMeansDenoisingImageFilter<itk::Image<float, 3u>, itk::Image<float, 3u>, itk::Image<unsigned char, 3u> >::BeforeThreadedGenerateData() (itkAdaptiveNonLocalMeansDenoisingImageFilter.hxx:140)`
