### PR TITLE
ENH:  Refactor all patch-based filters to new parent class.

### DIFF
--- a/Examples/antsJointFusion.cxx
+++ b/Examples/antsJointFusion.cxx
@@ -29,16 +29,30 @@ public:
   itkNewMacro( CommandProgressUpdate );
 protected:
 
-  CommandProgressUpdate() : m_CurrentProgress( 0 ) {};
+  CommandProgressUpdate() : m_CurrentProgress( 0 ), m_StartNewLine( true ) {};
 
   typedef TFilter FilterType;
 
   unsigned int m_CurrentProgress;
+  bool         m_StartNewLine;
 
 public:
 
   void Execute(itk::Object *caller, const itk::EventObject & event) ITK_OVERRIDE
     {
+    const TFilter * filter = dynamic_cast<const TFilter *>( caller );
+
+    if( this->m_CurrentProgress == 0 && ! filter->GetIsWeightedAveragingComplete() )
+      {
+      std::cout << "Weighted averaging: " << std::flush;
+      }
+    else if( this->m_StartNewLine && filter->GetIsWeightedAveragingComplete() )
+      {
+      std::cout << std::endl << "Reconstruction: " << std::flush;
+      this->m_StartNewLine = false;
+      this->m_CurrentProgress = 0;
+      }
+
     itk::ProcessObject *po = dynamic_cast<itk::ProcessObject *>( caller );
     if (! po) return;
 //    std::cout << po->GetProgress() << std::endl;
@@ -61,12 +75,26 @@ public:
 
   void Execute(const itk::Object * object, const itk::EventObject & event) ITK_OVERRIDE
     {
+    const TFilter * filter = dynamic_cast<const TFilter *>( object );
+
+    if( this->m_CurrentProgress == 0 && ! filter->GetIsWeightedAveragingComplete() )
+      {
+      std::cout << "Weighted averaging: " << std::flush;
+      }
+    else if( this->m_StartNewLine && filter->GetIsWeightedAveragingComplete() )
+      {
+      std::cout << std::endl << "Reconstruction: " << std::flush;
+      this->m_StartNewLine = false;
+      this->m_CurrentProgress = 0;
+      }
+
     itk::ProcessObject *po = dynamic_cast<itk::ProcessObject *>(
       const_cast<itk::Object *>( object ) );
     if (! po) return;
 
     if( typeid( event ) == typeid ( itk::ProgressEvent )  )
       {
+
       if( this->m_CurrentProgress < 99 )
         {
         this->m_CurrentProgress++;

--- a/Examples/antsJointFusion.cxx
+++ b/Examples/antsJointFusion.cxx
@@ -147,7 +147,7 @@ int antsJointFusion( itk::ants::CommandLineParser *parser )
       bool fileReadSuccessfully = ReadImage<RadiusImageType>( searchRadiusImage, searchRadiusString.c_str() );
       if( fileReadSuccessfully )
         {
-        fusionFilter->SetSearchNeighborhoodRadiusImage( searchRadiusImage );
+        fusionFilter->SetNeighborhoodSearchRadiusImage( searchRadiusImage );
         }
       else
         {
@@ -186,7 +186,7 @@ int antsJointFusion( itk::ants::CommandLineParser *parser )
         {
         searchNeighborhoodRadius[d] = searchRadius[d];
         }
-      fusionFilter->SetSearchNeighborhoodRadius( searchNeighborhoodRadius );
+      fusionFilter->SetNeighborhoodSearchRadius( searchNeighborhoodRadius );
       }
     }
 
@@ -218,7 +218,7 @@ int antsJointFusion( itk::ants::CommandLineParser *parser )
     patchNeighborhoodRadius[d] = patchRadius[d];
     }
 
-  fusionFilter->SetPatchNeighborhoodRadius( patchNeighborhoodRadius );
+  fusionFilter->SetNeighborhoodPatchRadius( patchNeighborhoodRadius );
 
   // Check if the user wants to retain atlas voting and/or label posterior images
 

--- a/Examples/antsJointTensorFusion.cxx
+++ b/Examples/antsJointTensorFusion.cxx
@@ -202,8 +202,8 @@ int antsJointTensorFusion( itk::ants::CommandLineParser *parser )
     patchNeighborhoodRadius[d] = patchRadius[d];
     }
 
-  fusionFilter->SetSearchNeighborhoodRadius( searchNeighborhoodRadius );
-  fusionFilter->SetPatchNeighborhoodRadius( patchNeighborhoodRadius );
+  fusionFilter->SetNeighborhoodSearchRadius( searchNeighborhoodRadius );
+  fusionFilter->SetNeighborhoodPatchRadius( patchNeighborhoodRadius );
 
   // Retain atlas voting and label posterior images
 

--- a/ImageSegmentation/itkWeightedVotingFusionImageFilter.h
+++ b/ImageSegmentation/itkWeightedVotingFusionImageFilter.h
@@ -18,7 +18,7 @@
 #ifndef __itkWeightedVotingFusionImageFilter_h
 #define __itkWeightedVotingFusionImageFilter_h
 
-#include "itkImageToImageFilter.h"
+#include "itkNonLocalPatchBasedImageFilter.h"
 
 #include "itkConstNeighborhoodIterator.h"
 
@@ -52,17 +52,17 @@ namespace itk
 
 template <class TInputImage, class TOutputImage>
 class WeightedVotingFusionImageFilter
-: public ImageToImageFilter<TInputImage, TOutputImage>
+: public NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Standard class typedefs. */
-  typedef WeightedVotingFusionImageFilter                 Self;
-  typedef ImageToImageFilter<TInputImage, TOutputImage>   Superclass;
-  typedef SmartPointer<Self>                              Pointer;
-  typedef SmartPointer<const Self>                        ConstPointer;
+  typedef WeightedVotingFusionImageFilter                            Self;
+  typedef NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>   Superclass;
+  typedef SmartPointer<Self>                                         Pointer;
+  typedef SmartPointer<const Self>                                   ConstPointer;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro( WeightedVotingFusionImageFilter, ImageToImageFilter );
+  itkTypeMacro( WeightedVotingFusionImageFilter, NonLocalPatchBasedImageFilter );
 
   itkNewMacro( Self );
 
@@ -75,10 +75,11 @@ public:
   typedef typename InputImageType::Pointer           InputImagePointer;
   typedef typename InputImageType::ConstPointer      InputImageConstPointer;
   typedef typename InputImageType::PixelType         InputImagePixelType;
-  typedef std::vector<InputImagePointer>             InputImageList;
-  typedef std::vector<InputImageList>                InputImageSetList;
 
-  typedef std::vector<InputImagePixelType>           InputImagePixelVectorType;
+  typedef typename Superclass::InputImageList        InputImageList;
+  typedef typename Superclass::InputImageSetList     InputImageSetList;
+
+  typedef typename Superclass::InputImagePixelVectorType    InputImagePixelVectorType;
 
   typedef TOutputImage                               OutputImageType;
   typedef typename OutputImageType::PixelType        LabelType;
@@ -96,7 +97,6 @@ public:
   typedef typename InputImageType::SizeType          SizeType;
   typedef typename InputImageType::IndexType         IndexType;
 
-
   typedef Image<float, ImageDimension>               ProbabilityImageType;
   typedef typename ProbabilityImageType::Pointer     ProbabilityImagePointer;
 
@@ -110,20 +110,14 @@ public:
   typedef std::map<LabelType, LabelImagePointer>        LabelExclusionMap;
   typedef std::vector<ProbabilityImagePointer>          VotingWeightImageList;
 
-  typedef ConstNeighborhoodIterator<InputImageType>               ConstNeighborhoodIteratorType;
-  typedef typename ConstNeighborhoodIteratorType::RadiusType      NeighborhoodRadiusType;
-  typedef typename ConstNeighborhoodIteratorType::OffsetType      NeighborhoodOffsetType;
+  typedef typename Superclass::ConstNeighborhoodIteratorType      ConstNeighborhoodIteratorType;
+  typedef typename Superclass::NeighborhoodRadiusType             NeighborhoodRadiusType;
+  typedef typename Superclass::NeighborhoodOffsetType             NeighborhoodOffsetType;
+  typedef typename Superclass::NeighborhoodOffsetListType         NeighborhoodOffsetListType;
+
   typedef typename SizeType::SizeValueType                        RadiusValueType;
   typedef Image<RadiusValueType, ImageDimension>                  RadiusImageType;
   typedef typename RadiusImageType::Pointer                       RadiusImagePointer;
-
-  /**
-   * Neighborhood patch similarity metric enumerated type
-   */
-  enum SimilarityMetricType {
-    PEARSON_CORRELATION,
-    MEAN_SQUARES
-  };
 
   /**
    * Set the multimodal target image
@@ -195,26 +189,12 @@ public:
   itkGetConstMacro( LabelSet, LabelSetType );
 
   /**
-   * Set/Get the local search neighborhood for minimizing potential registration error.
-   * Default = 3x3x3.
-   */
-  itkSetMacro( SearchNeighborhoodRadius, NeighborhoodRadiusType );
-  itkGetConstMacro( SearchNeighborhoodRadius, NeighborhoodRadiusType );
-
-  /**
    * Set/Get the local search neighborhood radius image.
    */
-  void SetSearchNeighborhoodRadiusImage( RadiusImageType *image )
+  void SetNeighborhoodSearchRadiusImage( RadiusImageType *image )
     {
-    this->m_SearchNeighborhoodRadiusImage = image;
+    this->m_NeighborhoodSearchRadiusImage = image;
     }
-
-  /**
-   * Set/Get the patch neighborhood for calculating the similarity measures.
-   * Default = 2x2x2.
-   */
-  itkSetMacro( PatchNeighborhoodRadius, NeighborhoodRadiusType );
-  itkGetConstMacro( PatchNeighborhoodRadius, NeighborhoodRadiusType );
 
   /**
    * Set/Get the Alpha parameter---the regularization weight added to the matrix Mx for
@@ -261,12 +241,6 @@ public:
   itkSetMacro( ConstrainSolutionToNonnegativeWeights, bool );
   itkGetConstMacro( ConstrainSolutionToNonnegativeWeights, bool );
   itkBooleanMacro( ConstrainSolutionToNonnegativeWeights );
-
-  /**
-   * Measurement of neighborhood similarity.
-   */
-  itkSetMacro( SimilarityMetric, SimilarityMetricType );
-  itkGetConstMacro( SimilarityMetric, SimilarityMetricType );
 
   /**
    * Get the posterior probability image corresponding to a label.
@@ -353,14 +327,6 @@ private:
 
   void ThreadedGenerateDataForReconstruction( const RegionType &, ThreadIdType );
 
-  RealType ComputeNeighborhoodPatchSimilarity( const InputImageList &, const IndexType, const InputImagePixelVectorType &, const bool );
-
-  InputImagePixelVectorType VectorizeImageListPatch( const InputImageList &, const IndexType, const bool );
-
-  InputImagePixelVectorType VectorizeImagePatch( const InputImagePointer, const IndexType, const bool );
-
-  void GetMeanAndStandardDeviationOfVectorizedImagePatch( const InputImagePixelVectorType &, RealType &, RealType & );
-
   VectorType NonNegativeLeastSquares( const MatrixType, const VectorType, const RealType );
 
   void UpdateInputs();
@@ -385,8 +351,6 @@ private:
   LabelExclusionMap                                    m_LabelExclusionImages;
   MaskImagePointer                                     m_MaskImage;
 
-  RegionType                                           m_TargetImageRequestedRegion;
-
   typename CountImageType::Pointer                     m_CountImage;
 
   LabelSetType                                         m_LabelSet;
@@ -394,14 +358,8 @@ private:
   SizeValueType                                        m_NumberOfAtlasSegmentations;
   SizeValueType                                        m_NumberOfAtlasModalities;
 
-  NeighborhoodRadiusType                               m_SearchNeighborhoodRadius;
-  NeighborhoodRadiusType                               m_PatchNeighborhoodRadius;
-  SizeValueType                                        m_PatchNeighborhoodSize;
-  std::vector<NeighborhoodOffsetType>                  m_SearchNeighborhoodOffsetList;
   std::map<RadiusValueType,
-    std::vector<NeighborhoodOffsetType> >              m_SearchNeighborhoodOffsetSetsMap;
-
-  std::vector<NeighborhoodOffsetType>                  m_PatchNeighborhoodOffsetList;
+              NeighborhoodOffsetListType>              m_NeighborhoodSearchOffsetSetsMap;
 
   RealType                                             m_Alpha;
   RealType                                             m_Beta;
@@ -410,11 +368,9 @@ private:
   bool                                                 m_RetainAtlasVotingWeightImages;
   bool                                                 m_ConstrainSolutionToNonnegativeWeights;
 
-  SimilarityMetricType                                 m_SimilarityMetric;
-
   ProbabilityImagePointer                              m_WeightSumImage;
 
-  RadiusImagePointer                                   m_SearchNeighborhoodRadiusImage;
+  RadiusImagePointer                                   m_NeighborhoodSearchRadiusImage;
 
   /** Output variables     */
   LabelPosteriorProbabilityMap                         m_LabelPosteriorProbabilityImages;

--- a/ImageSegmentation/itkWeightedVotingFusionImageFilter.h
+++ b/ImageSegmentation/itkWeightedVotingFusionImageFilter.h
@@ -243,6 +243,11 @@ public:
   itkBooleanMacro( ConstrainSolutionToNonnegativeWeights );
 
   /**
+   * Get the current state for progress reporting.
+   */
+  itkGetConstMacro( IsWeightedAveragingComplete, bool );
+
+  /**
    * Get the posterior probability image corresponding to a label.
    */
   const ProbabilityImagePointer GetLabelPosteriorProbabilityImage( LabelType label )

--- a/ImageSegmentation/itkWeightedVotingFusionImageFilter.hxx
+++ b/ImageSegmentation/itkWeightedVotingFusionImageFilter.hxx
@@ -39,7 +39,6 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
   m_NumberOfAtlases( 0 ),
   m_NumberOfAtlasSegmentations( 0 ),
   m_NumberOfAtlasModalities( 0 ),
-  m_PatchNeighborhoodSize( 0 ),
   m_Alpha( 0.1 ),
   m_Beta( 2.0 ),
   m_RetainLabelPosteriorProbabilityImages( false ),
@@ -50,12 +49,9 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
 
   this->m_CountImage = ITK_NULLPTR;
 
-  this->m_SearchNeighborhoodRadiusImage = ITK_NULLPTR;
-  this->m_SearchNeighborhoodRadius.Fill( 3 );
+  this->m_NeighborhoodSearchRadiusImage = ITK_NULLPTR;
 
-  this->m_PatchNeighborhoodRadius.Fill( 2 );
-
-  this->m_SimilarityMetric = PEARSON_CORRELATION;
+  this->SetSimilarityMetric( Superclass::PEARSON_CORRELATION );
 }
 
 template <class TInputImage, class TOutputImage>
@@ -113,28 +109,28 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
   RegionType outRegion = this->GetOutput()->GetRequestedRegion();
 
   // Pad this region by the search window and patch size
-  if( this->m_SearchNeighborhoodRadiusImage.IsNull() )
+  if( this->m_NeighborhoodSearchRadiusImage.IsNull() )
     {
-    outRegion.PadByRadius( this->m_SearchNeighborhoodRadius );
+    outRegion.PadByRadius( this->GetNeighborhoodSearchRadius() );
     }
   else
     {
-    NeighborhoodRadiusType maxSearchNeighborhoodRadius;
-    maxSearchNeighborhoodRadius.Fill( 0 );
+    NeighborhoodRadiusType maxNeighborhoodSearchRadius;
+    maxNeighborhoodSearchRadius.Fill( 0 );
 
-    ImageRegionConstIterator<RadiusImageType> ItR( this->m_SearchNeighborhoodRadiusImage,
-      this->m_SearchNeighborhoodRadiusImage->GetRequestedRegion() );
+    ImageRegionConstIterator<RadiusImageType> ItR( this->m_NeighborhoodSearchRadiusImage,
+      this->m_NeighborhoodSearchRadiusImage->GetRequestedRegion() );
     for( ItR.GoToBegin(); !ItR.IsAtEnd(); ++ItR )
       {
       RadiusValueType localSearchRadius = ItR.Get();
-      if( localSearchRadius > maxSearchNeighborhoodRadius[0] )
+      if( localSearchRadius > maxNeighborhoodSearchRadius[0] )
         {
-        maxSearchNeighborhoodRadius.Fill( localSearchRadius );
+        maxNeighborhoodSearchRadius.Fill( localSearchRadius );
         }
       }
-    outRegion.PadByRadius( maxSearchNeighborhoodRadius );
+    outRegion.PadByRadius( maxNeighborhoodSearchRadius );
     }
-  outRegion.PadByRadius( this->m_PatchNeighborhoodRadius );
+  outRegion.PadByRadius( this->GetNeighborhoodPatchRadius() );
 
   // Iterate over all the inputs to this filter
 
@@ -143,7 +139,7 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
     InputImageType *input = this->m_TargetImage[i];
     if( i == 0 )
       {
-      this->m_TargetImageRequestedRegion = input->GetRequestedRegion();
+      this->SetTargetImageRegion( input->GetRequestedRegion() );
       }
     RegionType region = outRegion;
     region.Crop( input->GetLargestPossibleRegion() );
@@ -227,6 +223,8 @@ void
 WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
 ::BeforeThreadedGenerateData()
 {
+  Superclass::BeforeThreadedGenerateData();
+
   if( this->m_NumberOfAtlasSegmentations != this->m_NumberOfAtlases )
     {
     // Set the number of atlas segmentations to 0 since we're just going to
@@ -267,8 +265,7 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
     labelProbabilityImage->CopyInformation( this->m_TargetImage[0] );
     labelProbabilityImage->SetRegions( this->m_TargetImage[0]->GetRequestedRegion() );
     labelProbabilityImage->SetLargestPossibleRegion( this->m_TargetImage[0]->GetLargestPossibleRegion() );
-    labelProbabilityImage->Allocate();
-    labelProbabilityImage->FillBuffer( 0.0 );
+    labelProbabilityImage->Allocate( true );
 
     this->m_LabelPosteriorProbabilityImages.insert(
       std::pair<LabelType, ProbabilityImagePointer>( *labelIt, labelProbabilityImage ) );
@@ -286,8 +283,7 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
       this->m_AtlasVotingWeightImages[i]->CopyInformation( this->m_TargetImage[0] );
       this->m_AtlasVotingWeightImages[i]->SetRegions( this->m_TargetImage[0]->GetRequestedRegion() );
       this->m_AtlasVotingWeightImages[i]->SetLargestPossibleRegion( this->m_TargetImage[0]->GetLargestPossibleRegion() );
-      this->m_AtlasVotingWeightImages[i]->Allocate();
-      this->m_AtlasVotingWeightImages[i]->FillBuffer( 0.0 );
+      this->m_AtlasVotingWeightImages[i]->Allocate( true );
       }
     }
 
@@ -301,8 +297,7 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
     this->m_JointIntensityFusionImage[i]->CopyInformation( this->m_TargetImage[0] );
     this->m_JointIntensityFusionImage[i]->SetRegions( this->m_TargetImage[0]->GetRequestedRegion() );
     this->m_JointIntensityFusionImage[i]->SetLargestPossibleRegion( this->m_TargetImage[0]->GetLargestPossibleRegion() );
-    this->m_JointIntensityFusionImage[i]->Allocate();
-    this->m_JointIntensityFusionImage[i]->FillBuffer( 0.0 );
+    this->m_JointIntensityFusionImage[i]->Allocate( true );
     }
 
   // Initialize the weight sum image
@@ -310,35 +305,33 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
   this->m_WeightSumImage->CopyInformation( this->m_TargetImage[0] );
   this->m_WeightSumImage->SetRegions( this->m_TargetImage[0]->GetRequestedRegion() );
   this->m_WeightSumImage->SetLargestPossibleRegion( this->m_TargetImage[0]->GetLargestPossibleRegion() );
-  this->m_WeightSumImage->Allocate();
-  this->m_WeightSumImage->FillBuffer( 0.0 );
+  this->m_WeightSumImage->Allocate( true );
 
   // Initialize the count image
   this->m_CountImage = CountImageType::New();
   this->m_CountImage->CopyInformation( this->m_TargetImage[0] );
   this->m_CountImage->SetRegions( this->m_TargetImage[0]->GetRequestedRegion() );
   this->m_CountImage->SetLargestPossibleRegion( this->m_TargetImage[0]->GetLargestPossibleRegion() );
-  this->m_CountImage->Allocate();
-  this->m_CountImage->FillBuffer( 0 );
+  this->m_CountImage->Allocate( true );
 
-  // Determine the search offset list (or map if an search radius image is specified)
+  // Determine the ordered search offset list (or map if an search radius image is specified)
 
   typename InputImageType::SpacingType spacing = this->m_TargetImage[0]->GetSpacing();
 
-  this->m_SearchNeighborhoodOffsetList.clear();
-  this->m_SearchNeighborhoodOffsetSetsMap.clear();
+  NeighborhoodOffsetListType orderedNeighborhoodSearchOffsetList;
+  orderedNeighborhoodSearchOffsetList.clear();
 
-  if( this->m_SearchNeighborhoodRadiusImage.IsNull() )
+  this->m_NeighborhoodSearchOffsetSetsMap.clear();
+
+  if( this->m_NeighborhoodSearchRadiusImage.IsNull() )
     {
-    ConstNeighborhoodIterator<InputImageType> It( this->m_SearchNeighborhoodRadius,
+    ConstNeighborhoodIterator<InputImageType> It( this->GetNeighborhoodSearchRadius(),
       this->GetInput(), this->GetInput()->GetRequestedRegion() );
 
-    SizeValueType searchNeighborhoodSize = ( It.GetNeighborhood() ).Size();
-
     DistanceIndexVectorType squaredDistances;
-    squaredDistances.resize( searchNeighborhoodSize );
+    squaredDistances.resize( this->GetNeighborhoodSearchSize() );
 
-    for( unsigned int n = 0; n < searchNeighborhoodSize; n++ )
+    for( unsigned int n = 0; n < this->GetNeighborhoodSearchSize(); n++ )
       {
       NeighborhoodOffsetType offset = ( It.GetNeighborhood() ).GetOffset( n );
 
@@ -351,37 +344,38 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
       }
     std::sort( squaredDistances.begin(), squaredDistances.end(), DistanceIndexComparator() );
 
-    for( unsigned int n = 0; n < searchNeighborhoodSize; n++ )
+    for( unsigned int n = 0; n < this->GetNeighborhoodSearchSize(); n++ )
       {
-      this->m_SearchNeighborhoodOffsetList.push_back( ( It.GetNeighborhood() ).GetOffset( squaredDistances[n].first ) );
+      orderedNeighborhoodSearchOffsetList.push_back( ( It.GetNeighborhood() ).GetOffset( squaredDistances[n].first ) );
       }
+    this->SetNeighborhoodSearchOffsetList( orderedNeighborhoodSearchOffsetList );
     }
   else
     {
-    ImageRegionConstIterator<RadiusImageType> ItR( this->m_SearchNeighborhoodRadiusImage,
-      this->m_SearchNeighborhoodRadiusImage->GetRequestedRegion() );
+    ImageRegionConstIterator<RadiusImageType> ItR( this->m_NeighborhoodSearchRadiusImage,
+      this->m_NeighborhoodSearchRadiusImage->GetRequestedRegion() );
 
     for( ItR.GoToBegin(); !ItR.IsAtEnd(); ++ItR )
       {
       RadiusValueType localSearchRadius = ItR.Get();
       if( localSearchRadius > 0 &&
-        this->m_SearchNeighborhoodOffsetSetsMap.find( localSearchRadius ) ==
-          this->m_SearchNeighborhoodOffsetSetsMap.end() )
+        this->m_NeighborhoodSearchOffsetSetsMap.find( localSearchRadius ) ==
+          this->m_NeighborhoodSearchOffsetSetsMap.end() )
         {
-        NeighborhoodRadiusType localSearchNeighborhoodRadius;
-        localSearchNeighborhoodRadius.Fill( localSearchRadius );
+        NeighborhoodRadiusType localNeighborhoodSearchRadius;
+        localNeighborhoodSearchRadius.Fill( localSearchRadius );
 
-        std::vector<NeighborhoodOffsetType> localSearchNeighborhoodOffsetList;
+        std::vector<NeighborhoodOffsetType> localNeighborhoodSearchOffsetList;
 
-        ConstNeighborhoodIterator<InputImageType> It( localSearchNeighborhoodRadius,
+        ConstNeighborhoodIterator<InputImageType> It( localNeighborhoodSearchRadius,
           this->GetInput(), this->GetInput()->GetRequestedRegion() );
 
-        RadiusValueType localSearchNeighborhoodSize = ( It.GetNeighborhood() ).Size();
+        RadiusValueType localNeighborhoodSearchSize = ( It.GetNeighborhood() ).Size();
 
         DistanceIndexVectorType squaredDistances;
-        squaredDistances.resize( localSearchNeighborhoodSize );
+        squaredDistances.resize( localNeighborhoodSearchSize );
 
-        for( unsigned int n = 0; n < localSearchNeighborhoodSize; n++ )
+        for( unsigned int n = 0; n < localNeighborhoodSearchSize; n++ )
           {
           NeighborhoodOffsetType offset = ( It.GetNeighborhood() ).GetOffset( n );
 
@@ -394,26 +388,13 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
           }
         std::sort( squaredDistances.begin(), squaredDistances.end(), DistanceIndexComparator() );
 
-        for( unsigned int n = 0; n < localSearchNeighborhoodSize; n++ )
+        for( unsigned int n = 0; n < localNeighborhoodSearchSize; n++ )
           {
-          localSearchNeighborhoodOffsetList.push_back( ( It.GetNeighborhood() ).GetOffset( squaredDistances[n].first ) );
+          localNeighborhoodSearchOffsetList.push_back( ( It.GetNeighborhood() ).GetOffset( squaredDistances[n].first ) );
           }
-        this->m_SearchNeighborhoodOffsetSetsMap[localSearchRadius] = localSearchNeighborhoodOffsetList;
+        this->m_NeighborhoodSearchOffsetSetsMap[localSearchRadius] = localNeighborhoodSearchOffsetList;
         }
       }
-    }
-
-  // Determine the patch offset list
-
-  ConstNeighborhoodIterator<InputImageType> It2( this->m_PatchNeighborhoodRadius,
-    this->GetInput(), this->GetInput()->GetRequestedRegion() );
-
-  this->m_PatchNeighborhoodOffsetList.clear();
-
-  this->m_PatchNeighborhoodSize = ( It2.GetNeighborhood() ).Size();
-  for( unsigned int n = 0; n < this->m_PatchNeighborhoodSize; n++ )
-    {
-    this->m_PatchNeighborhoodOffsetList.push_back( ( It2.GetNeighborhood() ).GetOffset( n ) );
     }
 
   this->AllocateOutputs();
@@ -446,10 +427,10 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
   SizeValueType numberOfTargetModalities = this->m_TargetImage.size();
 
   MatrixType absoluteAtlasPatchDifferences( this->m_NumberOfAtlases,
-    this->m_PatchNeighborhoodSize * numberOfTargetModalities );
+    this->GetNeighborhoodPatchSize() * numberOfTargetModalities );
 
   MatrixType originalAtlasPatchIntensities( this->m_NumberOfAtlases,
-    this->m_PatchNeighborhoodSize * this->m_NumberOfAtlasModalities );
+    this->GetNeighborhoodPatchSize() * this->m_NumberOfAtlasModalities );
 
   std::vector<SizeValueType> minimumAtlasOffsetIndices( this->m_NumberOfAtlases );
 
@@ -460,7 +441,7 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
     }
 
   // Iterate over the input region
-  ConstNeighborhoodIteratorType ItN( this->m_PatchNeighborhoodRadius, this->m_TargetImage[0], region );
+  ConstNeighborhoodIteratorType ItN( this->GetNeighborhoodPatchRadius(), this->m_TargetImage[0], region );
   for( ItN.GoToBegin(); !ItN.IsAtEnd(); ++ItN )
     {
     progress.CompletedPixel();
@@ -497,19 +478,19 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
 
     // Determine the search neighborhood offset list for the current center voxel
     std::vector<NeighborhoodOffsetType> searchNeighborhoodOffsetList;
-    if( this->m_SearchNeighborhoodRadiusImage.IsNull() )
+    if( this->m_NeighborhoodSearchRadiusImage.IsNull() )
       {
-      searchNeighborhoodOffsetList = this->m_SearchNeighborhoodOffsetList;
+      searchNeighborhoodOffsetList = this->GetNeighborhoodSearchOffsetList();
       }
     else
       {
       RadiusValueType localSearchRadius =
-        this->m_SearchNeighborhoodRadiusImage->GetPixel( currentCenterIndex );
+        this->m_NeighborhoodSearchRadiusImage->GetPixel( currentCenterIndex );
       if( localSearchRadius <= 0 )
         {
         continue;
         }
-      searchNeighborhoodOffsetList = this->m_SearchNeighborhoodOffsetSetsMap[localSearchRadius];
+      searchNeighborhoodOffsetList = this->m_NeighborhoodSearchOffsetSetsMap[localSearchRadius];
       }
     SizeValueType searchNeighborhoodSize = searchNeighborhoodOffsetList.size();
 
@@ -596,11 +577,11 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
         {
         RealType mxValue = 0.0;
 
-        for( unsigned int k = 0; k < this->m_PatchNeighborhoodSize * numberOfTargetModalities; k++ )
+        for( unsigned int k = 0; k < this->GetNeighborhoodPatchSize() * numberOfTargetModalities; k++ )
           {
           mxValue += absoluteAtlasPatchDifferences[i][k] * absoluteAtlasPatchDifferences[j][k];
           }
-        mxValue /= static_cast<RealType>( this->m_PatchNeighborhoodSize - 1 );
+        mxValue /= static_cast<RealType>( this->GetNeighborhoodPatchSize() - 1 );
 
         if( this->m_Beta == 2.0 )
           {
@@ -666,7 +647,7 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
 
     for( SizeValueType i = 0; i < this->m_NumberOfAtlasModalities; i++ )
       {
-      for( SizeValueType j = 0; j < this->m_PatchNeighborhoodSize; j++ )
+      for( SizeValueType j = 0; j < this->GetNeighborhoodPatchSize(); j++ )
         {
         IndexType neighborhoodIndex = ItN.GetIndex( j );
 
@@ -682,7 +663,7 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
           }
 
         RealType estimatedValue = (
-          estimatedNeighborhoodIntensities[i * this->m_PatchNeighborhoodSize + j] +
+          estimatedNeighborhoodIntensities[i * this->GetNeighborhoodPatchSize() + j] +
           this->m_JointIntensityFusionImage[i]->GetPixel( neighborhoodIndex ) );
 
         if( !std::isfinite( estimatedValue ) )
@@ -703,7 +684,7 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
     if( this->m_NumberOfAtlasSegmentations > 0 )
       {
       // Perform voting using Hongzhi's averaging scheme. Iterate over all segmentation patches
-      for( SizeValueType n = 0; n < this->m_PatchNeighborhoodSize; n++ )
+      for( SizeValueType n = 0; n < this->GetNeighborhoodPatchSize(); n++ )
         {
         IndexType neighborhoodIndex = ItN.GetIndex( n );
         if( !output->GetRequestedRegion().IsInside( neighborhoodIndex ) )
@@ -858,155 +839,6 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
         ItJ.Set( ItJ.Get() / static_cast<RealType>( count ) );
         }
       }
-    }
-}
-
-template <class TInputImage, class TOutputImage>
-typename WeightedVotingFusionImageFilter<TInputImage, TOutputImage>::InputImagePixelVectorType
-WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
-::VectorizeImageListPatch( const InputImageList &imageList, const IndexType index, const bool normalize )
-{
-  InputImagePixelVectorType patchVector( this->m_PatchNeighborhoodSize * imageList.size() );
-  for( unsigned int i = 0; i < imageList.size(); i++ )
-    {
-    InputImagePixelVectorType patchVectorPerModality = this->VectorizeImagePatch( imageList[i], index, normalize );
-    for( unsigned int j = 0; j < this->m_PatchNeighborhoodSize; j++ )
-      {
-      patchVector[i * this->m_PatchNeighborhoodSize + j] = patchVectorPerModality[j];
-      }
-    }
-  return patchVector;
-}
-
-template <class TInputImage, class TOutputImage>
-typename WeightedVotingFusionImageFilter<TInputImage, TOutputImage>::InputImagePixelVectorType
-WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
-::VectorizeImagePatch( const InputImagePointer image, const IndexType index, const bool normalize )
-{
-  InputImagePixelVectorType patchVector( this->m_PatchNeighborhoodSize );
-  for( SizeValueType i = 0; i < this->m_PatchNeighborhoodSize; i++ )
-    {
-    IndexType neighborhoodIndex = index + this->m_PatchNeighborhoodOffsetList[i];
-
-    bool isInBounds = this->m_TargetImageRequestedRegion.IsInside( neighborhoodIndex );
-    if( isInBounds )
-      {
-      InputImagePixelType pixel = image->GetPixel( neighborhoodIndex );
-      patchVector[i] = pixel;
-      }
-    else
-      {
-      patchVector[i] = std::numeric_limits<RealType>::quiet_NaN();
-      }
-    }
-
-  if( normalize )
-    {
-    RealType mean = 0.0;
-    RealType standardDeviation = 0.0;
-    this->GetMeanAndStandardDeviationOfVectorizedImagePatch( patchVector, mean, standardDeviation );
-
-    standardDeviation = std::max( standardDeviation, 1.0 );
-
-    typename InputImagePixelVectorType::iterator it;
-    for( it = patchVector.begin(); it != patchVector.end(); ++it )
-      {
-      *it = ( *it - mean ) / standardDeviation;
-      }
-    }
-  return patchVector;
-}
-
-template <class TInputImage, class TOutputImage>
-void
-WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
-::GetMeanAndStandardDeviationOfVectorizedImagePatch(
-  const InputImagePixelVectorType &patchVector, RealType &mean, RealType &standardDeviation )
-{
-  RealType sum = 0.0;
-  RealType sumOfSquares = 0.0;
-  RealType count = 0.0;
-
-  typename InputImagePixelVectorType::const_iterator it;
-  for( it = patchVector.begin(); it != patchVector.end(); ++it )
-    {
-    if( std::isfinite( *it ) )
-      {
-      sum += *it;
-      sumOfSquares += vnl_math_sqr( *it );
-      count += 1.0;
-      }
-    }
-
-  mean = sum / count;
-  standardDeviation = std::sqrt( ( sumOfSquares - count * vnl_math_sqr( mean ) ) / ( count - 1.0 ) );
-}
-
-template <class TInputImage, class TOutputImage>
-typename WeightedVotingFusionImageFilter<TInputImage, TOutputImage>::RealType
-WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
-::ComputeNeighborhoodPatchSimilarity( const InputImageList &imageList, const IndexType index,
-  const InputImagePixelVectorType &patchVectorY, const bool useOnlyFirstImage )
-{
-  unsigned int numberOfImagesToUse = imageList.size();
-  if( useOnlyFirstImage )
-    {
-    numberOfImagesToUse = 1;
-    }
-
-  RealType sumX = 0.0;
-  RealType sumOfSquaresX = 0.0;
-  RealType sumOfSquaredDifferencesXY = 0.0;
-  RealType sumXY = 0.0;
-  RealType N = 0.0;
-
-  SizeValueType count = 0;
-  for( SizeValueType i = 0; i < numberOfImagesToUse; i++ )
-    {
-    for( SizeValueType j = 0; j < this->m_PatchNeighborhoodSize; j++ )
-      {
-      IndexType neighborhoodIndex = index + this->m_PatchNeighborhoodOffsetList[j];
-
-      bool isInBounds = this->m_TargetImageRequestedRegion.IsInside( neighborhoodIndex );
-      if( isInBounds && std::isfinite( patchVectorY[count] ) )
-        {
-        RealType x = static_cast<RealType>( imageList[i]->GetPixel( neighborhoodIndex ) );
-        RealType y = static_cast<RealType>( patchVectorY[count] );
-
-        sumX += x;
-        sumOfSquaresX += vnl_math_sqr( x );
-        sumXY += ( x * y );
-
-        sumOfSquaredDifferencesXY += vnl_math_sqr( y - x );
-        N += 1.0;
-        }
-      ++count;
-      }
-    }
-
-  // If we are on the boundary, a neighborhood patch might not overlap
-  // with the image.  If we have 2 voxels or less for a neighborhood patch
-  // we don't consider it to be a suitable match.
-  if( N < 3.0 )
-    {
-    return NumericTraits<RealType>::max();
-    }
-
-  if( this->m_SimilarityMetric == PEARSON_CORRELATION )
-    {
-    RealType varianceX = sumOfSquaresX - vnl_math_sqr( sumX ) / N;
-    varianceX = std::max( varianceX, 1.0e-6 );
-
-    RealType measure = vnl_math_sqr( sumXY ) / varianceX;
-    return ( sumXY > 0 ? -measure : measure );
-    }
-  else if( this->m_SimilarityMetric == MEAN_SQUARES )
-    {
-    return ( sumOfSquaredDifferencesXY / N );
-    }
-  else
-    {
-    itkExceptionMacro( "Unrecognized similarity metric." );
     }
 }
 
@@ -1175,16 +1007,6 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
   os << "Number of atlas modalities = " << this->m_NumberOfAtlasModalities << std::endl;
   os << "Alpha = " << this->m_Alpha << std::endl;
   os << "Beta = " << this->m_Beta << std::endl;
-  os << "Search neighborhood radius = " << this->m_SearchNeighborhoodRadius << std::endl;
-  os << "Patch neighborhood radius = " << this->m_PatchNeighborhoodRadius << std::endl;
-  if( this->m_SimilarityMetric == PEARSON_CORRELATION )
-    {
-    os << "Using Pearson correlation to measure the patch similarity." << std::endl;
-    }
-  else if( this->m_SimilarityMetric == MEAN_SQUARES )
-    {
-    os << "Using mean squares to measure the patch similarity." << std::endl;
-    }
   if( this->m_ConstrainSolutionToNonnegativeWeights )
     {
     os << "Constrain solution to positive weights using NNLS." << std::endl;

--- a/ImageSegmentation/itkWeightedVotingFusionImageFilter.hxx
+++ b/ImageSegmentation/itkWeightedVotingFusionImageFilter.hxx
@@ -730,9 +730,10 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
 template <class TInputImage, class TOutputImage>
 void
 WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
-::ThreadedGenerateDataForReconstruction( const RegionType &region, ThreadIdType
-  itkNotUsed( threadId ) )
+::ThreadedGenerateDataForReconstruction( const RegionType &region, ThreadIdType threadId )
 {
+  ProgressReporter progress( this, threadId, 2 * region.GetNumberOfPixels(), 100 );
+
   typename OutputImageType::Pointer output = this->GetOutput();
 
   // Perform voting at each voxel
@@ -740,6 +741,8 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
 
   for( It.GoToBegin(); !It.IsAtEnd(); ++It )
     {
+    progress.CompletedPixel();
+
     IndexType index = It.GetIndex();
 
     if( this->m_MaskImage &&
@@ -779,6 +782,8 @@ WeightedVotingFusionImageFilter<TInputImage, TOutputImage>
 
   for( ItW.GoToBegin(); !ItW.IsAtEnd(); ++ItW )
     {
+    progress.CompletedPixel();
+
     typename ProbabilityImageType::PixelType weightSum = ItW.Get();
 
     IndexType index = ItW.GetIndex();

--- a/Utilities/itkAdaptiveNonLocalMeansDenoisingImageFilter.h
+++ b/Utilities/itkAdaptiveNonLocalMeansDenoisingImageFilter.h
@@ -18,7 +18,7 @@
 #ifndef itkAdaptiveNonLocalMeansDenoisingImageFilter_h
 #define itkAdaptiveNonLocalMeansDenoisingImageFilter_h
 
-#include "itkImageToImageFilter.h"
+#include "itkNonLocalPatchBasedImageFilter.h"
 
 #include "itkConstNeighborhoodIterator.h"
 #include "itkGaussianOperator.h"
@@ -47,17 +47,17 @@ template<typename TInputImage,
   class TOutputImage = TInputImage,
   typename TMaskImage = Image<unsigned char, TInputImage::ImageDimension> >
 class AdaptiveNonLocalMeansDenoisingImageFilter :
-  public ImageToImageFilter<TInputImage, TOutputImage>
+  public NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>
 {
 public:
   /** Standard class typedefs. */
-  typedef AdaptiveNonLocalMeansDenoisingImageFilter     Self;
-  typedef ImageToImageFilter<TInputImage, TOutputImage> Superclass;
-  typedef SmartPointer<Self>                            Pointer;
-  typedef SmartPointer<const Self>                      ConstPointer;
+  typedef AdaptiveNonLocalMeansDenoisingImageFilter                 Self;
+  typedef NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>  Superclass;
+  typedef SmartPointer<Self>                                        Pointer;
+  typedef SmartPointer<const Self>                                  ConstPointer;
 
   /** Runtime information support. */
-  itkTypeMacro( AdaptiveNonLocalMeansDenoisingImageFilter, ImageToImageFilter );
+  itkTypeMacro( AdaptiveNonLocalMeansDenoisingImageFilter, NonLocalPatchBasedImageFilter );
 
   /** Standard New method. */
   itkNewMacro( Self );
@@ -70,22 +70,22 @@ public:
   typedef TInputImage                                    InputImageType;
   typedef typename InputImageType::PixelType             InputPixelType;
   typedef TOutputImage                                   OutputImageType;
-  typedef typename InputImageType::RegionType            RegionType;
+  typedef typename Superclass::RegionType                RegionType;
 
   typedef TMaskImage                                     MaskImageType;
   typedef typename MaskImageType::PixelType              MaskPixelType;
   typedef typename MaskImageType::PixelType              LabelType;
 
-  typedef float                                          RealType;
-  typedef Image<RealType, ImageDimension>                RealImageType;
-  typedef typename RealImageType::Pointer                RealImagePointer;
-  typedef typename RealImageType::IndexType              IndexType;
+  typedef typename Superclass::RealType                  RealType;
+  typedef typename Superclass::RealImageType             RealImageType;
+  typedef typename Superclass::RealImagePointer          RealImagePointer;
+  typedef typename Superclass::IndexType                 IndexType;
+
+  typedef typename Superclass::ConstNeighborhoodIteratorType   ConstNeighborhoodIteratorType;
+  typedef typename Superclass::NeighborhoodRadiusType          NeighborhoodRadiusType;
+  typedef typename Superclass::NeighborhoodOffsetType          NeighborhoodOffsetType;
 
   typedef GaussianOperator<RealType>                     ModifiedBesselCalculatorType;
-
-  typedef ConstNeighborhoodIterator<RealImageType>             ConstNeighborhoodIteratorType;
-  typedef typename ConstNeighborhoodIteratorType::RadiusType   NeighborhoodRadiusType;
-  typedef typename ConstNeighborhoodIteratorType::OffsetType   NeighborhoodOffsetType;
 
   /**
    * The image expected for input for noise correction.
@@ -153,25 +153,11 @@ public:
   itkGetConstMacro( VarianceThreshold, RealType );
 
   /**
-   * Neighborhood size for computing local mean and variance images.
+   * Neighborhood for computing local mean and variance images.
    * Default = 1x1x...
    */
   itkSetMacro( NeighborhoodRadiusForLocalMeanAndVariance, NeighborhoodRadiusType );
   itkGetConstMacro( NeighborhoodRadiusForLocalMeanAndVariance, NeighborhoodRadiusType );
-
-  /**
-   * Neighborhood search radius.
-   * Default = 3x3x...
-   */
-  itkSetMacro( NeighborhoodSearchRadius, NeighborhoodRadiusType );
-  itkGetConstMacro( NeighborhoodSearchRadius, NeighborhoodRadiusType );
-
-  /**
-   * Neighborhood block radius.
-   * Default = 1x1x...
-   */
-  itkSetMacro( NeighborhoodPatchRadius, NeighborhoodRadiusType );
-  itkGetConstMacro( NeighborhoodPatchRadius, NeighborhoodRadiusType );
 
 protected:
   AdaptiveNonLocalMeansDenoisingImageFilter();
@@ -212,10 +198,6 @@ private:
   RealImagePointer                  m_IntensitySquaredDistanceImage;
 
   NeighborhoodRadiusType            m_NeighborhoodRadiusForLocalMeanAndVariance;
-  NeighborhoodRadiusType            m_NeighborhoodSearchRadius;
-  NeighborhoodRadiusType            m_NeighborhoodPatchRadius;
-
-  std::vector<NeighborhoodOffsetType>  m_NeighborhoodOffsetList;
 };
 
 } // end namespace itk

--- a/Utilities/itkNonLocalPatchBasedImageFilter.h
+++ b/Utilities/itkNonLocalPatchBasedImageFilter.h
@@ -1,0 +1,179 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkNonLocalPatchBasedImageFilter_h
+#define itkNonLocalPatchBasedImageFilter_h
+
+#include "itkImageToImageFilter.h"
+
+#include "itkConstNeighborhoodIterator.h"
+
+namespace itk {
+
+/**
+ * \class NonLocalPatchBasedImageFilter
+ * \brief Implementation of a non-local upsampling (i.e., superresolution) image filter.
+ *
+ * \ingroup ITKFiltering
+ */
+
+template<typename TInputImage, class TOutputImage = TInputImage>
+class NonLocalPatchBasedImageFilter :
+  public ImageToImageFilter<TInputImage, TOutputImage>
+{
+public:
+  /** Standard class typedefs. */
+  typedef NonLocalPatchBasedImageFilter                 Self;
+  typedef ImageToImageFilter<TInputImage, TOutputImage> Superclass;
+  typedef SmartPointer<Self>                            Pointer;
+  typedef SmartPointer<const Self>                      ConstPointer;
+
+  /** Runtime information support. */
+  itkTypeMacro( NonLocalPatchBasedImageFilter, ImageToImageFilter );
+
+  /** Standard New method. */
+  itkNewMacro( Self );
+
+  /** ImageDimension constants */
+  itkStaticConstMacro( ImageDimension, unsigned int,
+                       TInputImage::ImageDimension );
+
+  /** Some convenient typedefs. */
+  typedef TInputImage                                    InputImageType;
+  typedef typename InputImageType::PixelType             InputPixelType;
+  typedef typename InputImageType::Pointer               InputImagePointer;
+  typedef std::vector<InputImagePointer>                 InputImageList;
+  typedef std::vector<InputImageList>                    InputImageSetList;
+  typedef typename InputImageType::RegionType            RegionType;
+
+  typedef TOutputImage                                   OutputImageType;
+  typedef typename OutputImageType::PixelType            OutputPixelType;
+
+  typedef std::vector<InputPixelType>                    InputImagePixelVectorType;
+
+  typedef float                                          RealType;
+  typedef Image<RealType, ImageDimension>                RealImageType;
+  typedef typename RealImageType::Pointer                RealImagePointer;
+  typedef typename RealImageType::IndexType              IndexType;
+
+  typedef Neighborhood<InputPixelType, ImageDimension>         NeighborhoodType;
+  typedef SizeValueType                                        NeighborhoodSizeType;
+
+  typedef ConstNeighborhoodIterator<InputImageType>            ConstNeighborhoodIteratorType;
+  typedef typename ConstNeighborhoodIteratorType::RadiusType   NeighborhoodRadiusType;
+  typedef typename ConstNeighborhoodIteratorType::OffsetType   NeighborhoodOffsetType;
+
+  typedef std::vector<NeighborhoodOffsetType>                  NeighborhoodOffsetListType;
+  /**
+   * Neighborhood patch similarity metric enumerated type
+   */
+  enum SimilarityMetricType {
+    PEARSON_CORRELATION,
+    MEAN_SQUARES
+  };
+
+  /**
+   * Get/set neighborhood search radius.
+   * Default = 3x3x...
+   */
+  itkSetMacro( NeighborhoodSearchRadius, NeighborhoodRadiusType );
+  itkGetConstMacro( NeighborhoodSearchRadius, NeighborhoodRadiusType );
+
+  /**
+   * Get/set neighborhood search size.
+   */
+  itkSetMacro( NeighborhoodSearchSize, NeighborhoodSizeType );
+  itkGetConstMacro( NeighborhoodSearchSize, NeighborhoodSizeType );
+
+  /**
+   * Get/set neighborhood search offset list.
+   */
+  itkSetMacro( NeighborhoodSearchOffsetList, NeighborhoodOffsetListType );
+  itkGetConstMacro( NeighborhoodSearchOffsetList, NeighborhoodOffsetListType );
+
+  /**
+   * Get/set neighborhood patch radius.
+   * Default = 1x1x...
+   */
+  itkSetMacro( NeighborhoodPatchRadius, NeighborhoodRadiusType );
+  itkGetConstMacro( NeighborhoodPatchRadius, NeighborhoodRadiusType );
+
+  /**
+   * Get/set neighborhood patch size.
+   */
+  itkSetMacro( NeighborhoodPatchSize, NeighborhoodSizeType );
+  itkGetConstMacro( NeighborhoodPatchSize, NeighborhoodSizeType );
+
+  /**
+   * Get/set neighborhood patch offset list.
+   */
+  itkSetMacro( NeighborhoodPatchOffsetList, NeighborhoodOffsetListType );
+  itkGetConstMacro( NeighborhoodPatchOffsetList, NeighborhoodOffsetListType );
+
+  /**
+   * Enumerated type for neighborhood similarity.  Default = MEAN_SQUARES
+   */
+  itkSetMacro( SimilarityMetric, SimilarityMetricType );
+  itkGetConstMacro( SimilarityMetric, SimilarityMetricType );
+
+protected:
+
+  NonLocalPatchBasedImageFilter();
+  ~NonLocalPatchBasedImageFilter() {}
+
+  void BeforeThreadedGenerateData() ITK_OVERRIDE;
+
+  void PrintSelf( std::ostream & os, Indent indent ) const ITK_OVERRIDE;
+
+  RealType ComputeNeighborhoodPatchSimilarity( const InputImageList &, const IndexType, const InputImagePixelVectorType &, const bool );
+
+  InputImagePixelVectorType VectorizeImageListPatch( const InputImageList &, const IndexType, const bool );
+
+  InputImagePixelVectorType VectorizeImagePatch( const InputImagePointer, const IndexType, const bool );
+
+  void GetMeanAndStandardDeviationOfVectorizedImagePatch( const InputImagePixelVectorType &, RealType &, RealType & );
+
+  itkSetMacro( TargetImageRegion, RegionType );
+  itkGetConstMacro( TargetImageRegion, RegionType );
+
+  SimilarityMetricType                                 m_SimilarityMetric;
+
+  SizeValueType                                        m_NeighborhoodSearchSize;
+  NeighborhoodRadiusType                               m_NeighborhoodSearchRadius;
+  NeighborhoodOffsetListType                           m_NeighborhoodSearchOffsetList;
+
+  SizeValueType                                        m_NeighborhoodPatchSize;
+  NeighborhoodRadiusType                               m_NeighborhoodPatchRadius;
+  NeighborhoodOffsetListType                           m_NeighborhoodPatchOffsetList;
+
+  RegionType                                           m_TargetImageRegion;
+
+
+private:
+
+  NonLocalPatchBasedImageFilter( const Self& ) ITK_DELETE_FUNCTION;
+  void operator=( const Self& ) ITK_DELETE_FUNCTION;
+
+};
+
+} // end namespace itk
+
+#ifndef ITK_MANUAL_INSTANTIATION
+#include "itkNonLocalPatchBasedImageFilter.hxx"
+#endif
+
+#endif

--- a/Utilities/itkNonLocalPatchBasedImageFilter.hxx
+++ b/Utilities/itkNonLocalPatchBasedImageFilter.hxx
@@ -1,0 +1,251 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#ifndef itkNonLocalPatchBasedImageFilter_hxx
+#define itkNonLocalPatchBasedImageFilter_hxx
+
+#include "itkNonLocalPatchBasedImageFilter.h"
+
+#include "itkNeighborhood.h"
+
+namespace itk {
+
+template <typename TInputImage, typename TOutputImage>
+NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>
+::NonLocalPatchBasedImageFilter()
+{
+  this->m_SimilarityMetric = MEAN_SQUARES;
+
+  this->m_NeighborhoodPatchRadius.Fill( 1 );
+  this->m_NeighborhoodPatchOffsetList.clear();
+
+  this->m_NeighborhoodSearchRadius.Fill( 3 );
+  this->m_NeighborhoodSearchOffsetList.clear();
+}
+
+template<typename TInputImage, typename TOutputImage>
+void
+NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>
+::BeforeThreadedGenerateData()
+{
+  // Set up the search neighborhood parameters
+
+  this->m_NeighborhoodSearchOffsetList.clear();
+
+  NeighborhoodType searchNeighborhood;
+  searchNeighborhood.SetRadius( this->m_NeighborhoodSearchRadius );
+
+  this->m_NeighborhoodSearchSize = searchNeighborhood.Size();
+  for( unsigned int n = 0; n < this->m_NeighborhoodSearchSize; n++ )
+    {
+    this->m_NeighborhoodSearchOffsetList.push_back( searchNeighborhood.GetOffset( n ) );
+    }
+
+  // Set up the patch neighborhood parameters
+
+  this->m_NeighborhoodPatchOffsetList.clear();
+
+  NeighborhoodType patchNeighborhood;
+  patchNeighborhood.SetRadius( this->m_NeighborhoodPatchRadius );
+
+  this->m_NeighborhoodPatchSize = patchNeighborhood.Size();
+  for( unsigned int n = 0; n < this->m_NeighborhoodPatchSize; n++ )
+    {
+    this->m_NeighborhoodPatchOffsetList.push_back( patchNeighborhood.GetOffset( n ) );
+    }
+
+  this->m_TargetImageRegion = this->GetInput()->GetRequestedRegion();
+}
+
+template <class TInputImage, class TOutputImage>
+typename NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>::InputImagePixelVectorType
+NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>
+::VectorizeImageListPatch( const InputImageList &imageList, const IndexType index, const bool normalize )
+{
+  InputImagePixelVectorType patchVector( this->m_NeighborhoodPatchSize * imageList.size() );
+  for( unsigned int i = 0; i < imageList.size(); i++ )
+    {
+    InputImagePixelVectorType patchVectorPerModality = this->VectorizeImagePatch( imageList[i], index, normalize );
+    for( unsigned int j = 0; j < this->m_NeighborhoodPatchSize; j++ )
+      {
+      patchVector[i * this->m_NeighborhoodPatchSize + j] = patchVectorPerModality[j];
+      }
+    }
+  return patchVector;
+}
+
+template <class TInputImage, class TOutputImage>
+typename NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>::InputImagePixelVectorType
+NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>
+::VectorizeImagePatch( const InputImagePointer image, const IndexType index, const bool normalize )
+{
+  InputImagePixelVectorType patchVector( this->m_NeighborhoodPatchSize );
+  for( SizeValueType i = 0; i < this->m_NeighborhoodPatchSize; i++ )
+    {
+    IndexType neighborhoodIndex = index + this->m_NeighborhoodPatchOffsetList[i];
+
+    bool isInBounds = this->m_TargetImageRegion.IsInside( neighborhoodIndex );
+    if( isInBounds )
+      {
+      InputPixelType pixel = image->GetPixel( neighborhoodIndex );
+      patchVector[i] = pixel;
+      }
+    else
+      {
+      patchVector[i] = std::numeric_limits<RealType>::quiet_NaN();
+      }
+    }
+
+  if( normalize )
+    {
+    RealType mean = 0.0;
+    RealType standardDeviation = 0.0;
+    this->GetMeanAndStandardDeviationOfVectorizedImagePatch( patchVector, mean, standardDeviation );
+
+    standardDeviation = std::max( standardDeviation, NumericTraits<RealType>::OneValue() );
+
+    typename InputImagePixelVectorType::iterator it;
+    for( it = patchVector.begin(); it != patchVector.end(); ++it )
+      {
+      *it = ( *it - mean ) / standardDeviation;
+      }
+    }
+  return patchVector;
+}
+
+template <class TInputImage, class TOutputImage>
+void
+NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>
+::GetMeanAndStandardDeviationOfVectorizedImagePatch(
+  const InputImagePixelVectorType &patchVector, RealType &mean, RealType &standardDeviation )
+{
+  RealType sum = 0.0;
+  RealType sumOfSquares = 0.0;
+  RealType count = 0.0;
+
+  typename InputImagePixelVectorType::const_iterator it;
+  for( it = patchVector.begin(); it != patchVector.end(); ++it )
+    {
+    if( std::isfinite( *it ) )
+      {
+      sum += *it;
+      sumOfSquares += vnl_math_sqr( *it );
+      count += 1.0;
+      }
+    }
+  mean = sum / count;
+  standardDeviation = std::sqrt( ( sumOfSquares - count * vnl_math_sqr( mean ) ) / ( count - 1.0 ) );
+}
+
+template <class TInputImage, class TOutputImage>
+typename NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>::RealType
+NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>
+::ComputeNeighborhoodPatchSimilarity( const InputImageList &imageList, const IndexType index,
+  const InputImagePixelVectorType &patchVectorY, const bool useOnlyFirstImage )
+{
+  unsigned int numberOfImagesToUse = imageList.size();
+  if( useOnlyFirstImage )
+    {
+    numberOfImagesToUse = 1;
+    }
+
+  RealType sumX = 0.0;
+  RealType sumOfSquaresX = 0.0;
+  RealType sumOfSquaredDifferencesXY = 0.0;
+  RealType sumXY = 0.0;
+  RealType N = 0.0;
+
+  SizeValueType count = 0;
+  for( SizeValueType i = 0; i < numberOfImagesToUse; i++ )
+    {
+    for( SizeValueType j = 0; j < this->m_NeighborhoodPatchSize; j++ )
+      {
+      IndexType neighborhoodIndex = index + this->m_NeighborhoodPatchOffsetList[j];
+
+      bool isInBounds = this->m_TargetImageRegion.IsInside( neighborhoodIndex );
+      if( isInBounds && std::isfinite( patchVectorY[count] ) )
+        {
+        RealType x = static_cast<RealType>( imageList[i]->GetPixel( neighborhoodIndex ) );
+        RealType y = static_cast<RealType>( patchVectorY[count] );
+
+        sumX += x;
+        sumOfSquaresX += vnl_math_sqr( x );
+        sumXY += ( x * y );
+
+        sumOfSquaredDifferencesXY += vnl_math_sqr( y - x );
+        N += 1.0;
+        }
+      ++count;
+      }
+    }
+
+  // If we are on the boundary, a neighborhood patch might not overlap
+  // with the image.  If we have 2 voxels or less for a neighborhood patch
+  // we don't consider it to be a suitable match.
+  if( N < 3.0 )
+    {
+    return NumericTraits<RealType>::max();
+    }
+
+  if( this->m_SimilarityMetric == PEARSON_CORRELATION )
+    {
+    RealType varianceX = sumOfSquaresX - vnl_math_sqr( sumX ) / N;
+    varianceX = std::max( varianceX, static_cast<RealType>( 1.0e-6 ) );
+
+    RealType measure = vnl_math_sqr( sumXY ) / varianceX;
+    if( sumXY > 0 )
+      {
+      return -measure;
+      }
+    else
+      {
+      return measure;
+      }
+    }
+  else if( this->m_SimilarityMetric == MEAN_SQUARES )
+    {
+    return ( sumOfSquaredDifferencesXY / N );
+    }
+  else
+    {
+    itkExceptionMacro( "Unrecognized similarity metric." );
+    }
+}
+
+template<typename TInputImage, typename TOutputImage>
+void
+NonLocalPatchBasedImageFilter<TInputImage, TOutputImage>
+::PrintSelf( std::ostream &os, Indent indent ) const
+{
+  Superclass::PrintSelf( os, indent );
+
+  if( this->m_SimilarityMetric == PEARSON_CORRELATION )
+    {
+    os << "Using Pearson correlation to measure the patch similarity." << std::endl;
+    }
+  else if( this->m_SimilarityMetric == MEAN_SQUARES )
+    {
+    os << "Using mean squares to measure the patch similarity." << std::endl;
+    }
+
+  os << indent << "Neighborhood search radius = " << this->m_NeighborhoodSearchRadius << std::endl;
+  os << indent << "Neighborhood patch radius = " << this->m_NeighborhoodPatchRadius << std::endl;
+}
+
+} // end namespace itk
+
+#endif


### PR DESCRIPTION
This is a refactoring of all the patch-based filters (``antsJointFusion``, ``DenoiseImage``, and ``NonLocalSuperResolution``) to all derive from a single parent class.  @stnava  and @hjmjohnson, I think this might be useful to put in ITK proper.