### PR TITLE
Rigid template

### DIFF
--- a/Scripts/antsMultivariateTemplateConstruction2.sh
+++ b/Scripts/antsMultivariateTemplateConstruction2.sh
@@ -1379,7 +1379,6 @@ while [[ $i -lt ${ITERATIONLIMIT} ]];
             pexe="$pexe ${basecall} ${stageId} ${stage3} >> ${outdir}/job_${count}_metriclog.txt\n"
           elif [[ $NOWARP -eq 1 ]];
             then
-	      stage3="-t ${TRANSFORMATION} ${IMAGEMETRICSET} -c [${MAXITERATIONS},1e-9,10] -f ${SHRINKFACTORS} -s ${SMOOTHINGFACTORS} -o ${outdir}/${OUTWARPFN}"
     	      if [[ ${TRANSFORMATION} == "Affine"* ]]; 
 	        then
           	  # If affine, do standard rigid, then affine with levels, etc from command line


### PR DESCRIPTION
Two changes:

1. Use ImageMath to add a sharpening step if averaging the images with mean or median. This allows the same Laplacian sharpening that you get with the normalized mean.

2. Allow construction of rigid and affine templates, with parameters controlled from the command line. Previously one could build an affine-only template, but the registration parameters were hard coded. Now the command line choices of metric, levels, iterations, and smoothing are used for the final stage of registration, whether it is deformable, affine, or rigid.