### PR TITLE
fix bug in iMathFillHoles

### DIFF
--- a/Examples/iMathFunctions.hxx
+++ b/Examples/iMathFunctions.hxx
@@ -299,7 +299,7 @@ iMathFillHoles( typename ImageType::Pointer image, double holeParam )
               objectedge++;
               totaledge++;
               }
-            else if( (val2 == 1) && GHood.GetPixel(i) != lab )
+            else if( (val2 != 1) && GHood.GetPixel(i) != lab )
               {
               backgroundedge++;
               totaledge++;


### PR DESCRIPTION
seems like a small bug in `iMathFillHoles` - the if statements are the same, leading erat to always be 1.0 .. This means `iMath(img, 'FillHoles', holeParam)` automatically fills in every hole even if the hole has low confidence (low `erat`) and just doesnt fill in anything when holeParam = 1 (which i guess is correct result but not for the right reason)

Here's an example of a very easy problem:

iMath works for all cases except when holeParam == 1. With this fix, `erat` now gives an actual confidence value for each of the labels.
```R
img <- antsImageRead("outfile.jpeg")
img.0 <- iMath(img, "FillHoles", 0) # works
img.0 <- iMath(img, "FillHoles", 0.2) # works
img.1 <- iMath(img, "FillHoles", 1) # doesnt work
img.2 <- iMath(img, "FillHoles", 1.2) # works
```

Or maybe I'm missing something and this is expected behavior.. doubt it though.

Example image:
![outfile](https://user-images.githubusercontent.com/13004360/28472357-40b814ec-6e0e-11e7-8fec-858538b2df64.jpg)



