### PR TITLE
minor fix for DIMENSION setting in 2D atropos MRF

### DIFF
--- a/Scripts/antsBrainExtraction.sh
+++ b/Scripts/antsBrainExtraction.sh
@@ -267,7 +267,7 @@ else
 fi
 
 ATROPOS_BRAIN_EXTRACTION_MRF="[0.1,1x1x1]"
-if [[ DIMENSION -eq 2 ]];
+if [[ $DIMENSION -eq 2 ]];
   then
     ATROPOS_BRAIN_EXTRACTION_MRF="[0.1,1x1]"
   fi
@@ -275,7 +275,7 @@ if [[ DIMENSION -eq 2 ]];
 if [[ -z "$ATROPOS_SEGMENTATION_MRF" ]];
   then
     ATROPOS_SEGMENTATION_MRF="[0.1,1x1x1]";
-    if [[ DIMENSION -eq 2 ]];
+    if [[ $DIMENSION -eq 2 ]];
       then
         ATROPOS_SEGMENTATION_MRF="[0.1,1x1]"
       fi


### PR DESCRIPTION
Proposing a minor fix to antsBrainExtraction.sh
Looks to me like DIMENSION needed correcting to $DIMENSION for purposes of setting 2D atropos MRF.